### PR TITLE
Host static files from content dir.

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,8 +51,10 @@ app.all('*', function(req, res, next) {
         var slug = req.params[0];
         if(slug == '/') slug = '/index';
 
-        var filePath = raneto.config.content_dir + slug +'.md',
-            pageList = raneto.getPages(slug);
+        var pageList = raneto.getPages(slug);
+
+        var filePath = path.normalize(raneto.config.content_dir + slug);
+        if (!fs.existsSync(filePath)) filePath += '.md';
 
         if(slug == '/index' && !fs.existsSync(filePath)){
             return res.render('home', {
@@ -70,22 +72,29 @@ app.all('*', function(req, res, next) {
 
                 // File info
                 var stat = fs.lstatSync(filePath);
-                // Meta
-                var meta = raneto.processMeta(content);
-                content = raneto.stripMeta(content);
-                if(!meta.title) meta.title = raneto.slugToTitle(filePath);
-                // Content
-                content = raneto.processVars(content);
-                var html = marked(content);
 
-                return res.render('page', {
-                    config: config,
-                    pages: pageList,
-                    meta: meta,
-                    content: html,
-                    body_class: 'page-'+ raneto.cleanString(slug),
-                    last_modified: moment(stat.mtime).format('Do MMM YYYY')
-                });
+                //process markdown files
+                if (path.extname(filePath) == '.md') {
+                    // Meta
+                    var meta = raneto.processMeta(content);
+                    content = raneto.stripMeta(content);
+                    if(!meta.title) meta.title = raneto.slugToTitle(filePath);
+                    // Content
+                    content = raneto.processVars(content);
+                    var html = marked(content);
+
+                    return res.render('page', {
+                        config: config,
+                        pages: pageList,
+                        meta: meta,
+                        content: html,
+                        body_class: 'page-'+ raneto.cleanString(slug),
+                        last_modified: moment(stat.mtime).format('Do MMM YYYY')
+                    });
+                } else {
+                    //serve static file
+                    res.sendfile(filePath);
+                }
             });
         }
     } else {


### PR DESCRIPTION
I have made a new solution for hosting static files (images, mostly) from `content/` folder.

It's cleaner then previous one, and fallback to Markdown files.

This pull-request substitutes #9
