### PR TITLE
Use `config.base_url` in all views.

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -1,5 +1,5 @@
 <div class="home-search jumbotron row">
-	<form class="search-form form-inline" role="form" action="/">
+	<form class="search-form form-inline" role="form" action="{{config.base_url}}/">
 		<div class="form-group">
 			<label class="sr-only" for="home-search">Search the knowledge base</label>
 			<input type="search" class="form-control input-lg" name="search" id="home-search" size="50" placeholder="Search the knowledge base">
@@ -16,7 +16,7 @@
 					<h2 class="panel-heading">Main Articles</h2>
 					<ul class="list-group pages">
 						{{#files}}
-							<li class="list-group-item page"><a href="/{{slug}}">{{title}}</a></li>
+							<li class="list-group-item page"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
 						{{/files}}
 					</ul>
 				</div>
@@ -29,7 +29,7 @@
 				<h2 class="panel-heading">{{title}}</h2>
 				<ul class="list-group pages">
 					{{#files}}
-						<li class="list-group-item page"><a href="/{{slug}}">{{title}}</a></li>
+						<li class="list-group-item page"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
 					{{/files}}
 				</ul>
 			</div>

--- a/views/layout.html
+++ b/views/layout.html
@@ -7,10 +7,10 @@
 	{{#meta.description}}<meta name="description" content="{{meta.description}}">{{/meta.description}}
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<link rel="shortcut icon" href="/favicon.ico">
-	<link rel="stylesheet" href="/bower_components/bootstrap/dist/css/bootstrap.min.css">
-	<link rel="stylesheet" href="/bower_components/highlightjs/styles/solarized_light.css">
-	<link rel="stylesheet" href="/styles/raneto.css">
+	<link rel="shortcut icon" href="{{config.base_url}}/favicon.ico">
+	<link rel="stylesheet" href="{{config.base_url}}/bower_components/bootstrap/dist/css/bootstrap.min.css">
+	<link rel="stylesheet" href="{{config.base_url}}/bower_components/highlightjs/styles/solarized_light.css">
+	<link rel="stylesheet" href="{{config.base_url}}/styles/raneto.css">
 
 	{{{config.analytics}}}
 </head>
@@ -21,7 +21,7 @@
 			<div class="row">
 				<div class="col-sm-6">
 
-					<a href="/" class="logo">{{config.site_title}}</a>
+					<a href="{{config.base_url}}/" class="logo">{{config.site_title}}</a>
 
 				</div>
 				<div class="col-sm-6">
@@ -52,12 +52,12 @@
 		</div>
 	</footer>
 
-	<script src="/bower_components/jquery/dist/jquery.min.js"></script>
-	<script src="/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
-	<script src="/bower_components/highlightjs/highlight.pack.js"></script>
-	<script src="/bower_components/fitvids/jquery.fitvids.js"></script>
-	<script src="/bower_components/masonry/dist/masonry.pkgd.min.js"></script>
-	<script src="/scripts/raneto.js"></script>
+	<script src="{{config.base_url}}/bower_components/jquery/dist/jquery.min.js"></script>
+	<script src="{{config.base_url}}/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
+	<script src="{{config.base_url}}/bower_components/highlightjs/highlight.pack.js"></script>
+	<script src="{{config.base_url}}/bower_components/fitvids/jquery.fitvids.js"></script>
+	<script src="{{config.base_url}}/bower_components/masonry/dist/masonry.pkgd.min.js"></script>
+	<script src="{{config.base_url}}/scripts/raneto.js"></script>
 
 </body>
 </html>

--- a/views/page.html
+++ b/views/page.html
@@ -5,7 +5,7 @@
         {{#pages}}
             {{#is_index}}
                 {{#files}}
-                    <li class="page{{#active}} active{{/active}}"><a href="/{{slug}}">{{title}}</a></li>
+                    <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
                 {{/files}}
             {{/is_index}}
             {{^is_index}}
@@ -13,7 +13,7 @@
                 <h5 class="category-title">{{title}}</h5>
                 <ul class="pages">
                 {{#files}}
-                    <li class="page{{#active}} active{{/active}}"><a href="/{{slug}}">{{title}}</a></li>
+                    <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
                 {{/files}}
                 </ul>
             </li>

--- a/views/search.html
+++ b/views/search.html
@@ -5,7 +5,7 @@
         {{#pages}}
             {{#is_index}}
                 {{#files}}
-                    <li class="page{{#active}} active{{/active}}"><a href="/{{slug}}">{{title}}</a></li>
+                    <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
                 {{/files}}
             {{/is_index}}
             {{^is_index}}
@@ -13,7 +13,7 @@
                 <h5 class="category-title">{{title}}</h5>
                 <ul class="pages">
                 {{#files}}
-                    <li class="page{{#active}} active{{/active}}"><a href="/{{slug}}">{{title}}</a></li>
+                    <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
                 {{/files}}
                 </ul>
             </li>
@@ -29,7 +29,7 @@
             {{#searchResults.length}}
                 {{#searchResults}}
                 <div class="page">
-                    <h2 class="page-title"><a href="/{{slug}}">{{title}}</a></h2>
+                    <h2 class="page-title"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></h2>
                     <div class="page-excerpt">{{{excerpt}}}</div>
                 </div>
                 {{/searchResults}}


### PR DESCRIPTION
I set up Raneto using a proxy pass in some folder on my web server, but the URLs were always absolute to the root directory, not aware of the `config.base_url` value. This PR solves this.