### PR TITLE
highlight.js doesn't use the 'lang-' prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,6 +79,9 @@ app.all('*', function(req, res, next) {
                     if(!meta.title) meta.title = raneto.slugToTitle(filePath);
                     // Content
                     content = raneto.processVars(content);
+                    marked.setOptions({
+                    	langPrefix: ''
+                    });
                     var html = marked(content);
 
                     return res.render('page', {


### PR DESCRIPTION
Marked generates html classes with the language hint for the parser by default using the 'lang-' prefix on the class name, however highlight.js does not support this.

So even though one hints in one's own markdown files which language it is, highlightjs will ignore it and try to automatically detect (usually wrongly) because it's just looking for the language as a classname on the code block (see here: http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html).

Overriding the prefix in the marked options makes it render properly for highlightjs.