### PR TITLE
markdown live edit: moved buttons so that there is more horizontal ed…

### DIFF
--- a/themes/default/templates/edit.html
+++ b/themes/default/templates/edit.html
@@ -10,12 +10,19 @@
 
     <section class="content">
       <div class="alert alert-success" id="edit-status" style="display: none;" role="alert"></div>
-      <h3>Editor</h3>
+      
       <div class="btn-group btn-group-sm pull-right" role="group" aria-label="...">
         <button type="button" class="btn btn-primary close-edit">Close</button>
         <button type="button" class="btn btn-success save-page">Save</button>
       </div>
+      <h3>Editor</h3>
+
       <textarea id="entry-markdown">{{{content}}}</textarea>
+      
+      <div class="btn-group btn-group-sm pull-right" role="group" aria-label="...">
+        <button type="button" class="btn btn-primary close-edit">Close</button>
+        <button type="button" class="btn btn-success save-page">Save</button>
+      </div>
     </section>
 
   </div>


### PR DESCRIPTION
Increased the horizontal edit area size by moving the save/close button group above and below the text area.