### PR TITLE
Decode URI before saving for non-Latin characters

### DIFF
--- a/public/scripts/raneto.js
+++ b/public/scripts/raneto.js
@@ -107,7 +107,7 @@
       file_arr.pop();
       $("#entry-markdown").next(".CodeMirror")[0].CodeMirror.save();
       $.post("/rn-edit", {
-        file    : file_arr.join("/"),
+        file    : decodeURI(file_arr.join("/")),
         content : $("#entry-markdown").val()
       }, function (data) {
         switch (data.status) {


### PR DESCRIPTION
Non-Latin characters in Category or Article names are encoded within
page address and should be decoded back before sending page saving
request to API. Resolves #61.