### PR TITLE
Adding new page in 'Main articles'

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -108,7 +108,7 @@ function initialize (config) {
     });
 
     app.post('/rn-add-page', function (req, res, next) {
-      var filePath = path.normalize(raneto.config.content_dir + req.body.category + '/' + req.body.name + '.md');
+      var filePath = path.normalize(raneto.config.content_dir + (!!req.body.category ? req.body.category + '/' : '') + req.body.name + '.md');
       fs.open(filePath, 'a', function (err, fd) {
         fs.close(fd);
         if (err) {

--- a/public/scripts/raneto.js
+++ b/public/scripts/raneto.js
@@ -45,7 +45,7 @@
       }, function (data) {
         switch (data.status) {
           case 0:
-            window.location = "/" + current_category + "/" + name + "/edit";
+            window.location = [current_category, name, "edit"].join("/");
             break;
         }
       });
@@ -76,7 +76,7 @@
                     .trim()
                     .toLowerCase()
                     .replace(/\s+/g, "-");
-      current_category = text;
+      current_category = text != "main-articles" ? text : "";
     });
 
     // New Category

--- a/themes/default/templates/page.html
+++ b/themes/default/templates/page.html
@@ -7,21 +7,19 @@
         <li><input id="newCategory" type="text" class="form-control" placeholder="Add Category"/></li>
       {{/config.allow_editing}}
       {{#pages}}
-        {{#is_index}}
-          {{#files}}
-            <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
-          {{/files}}
-        {{/is_index}}
-        {{^is_index}}
-          <li class="category">
-            <h5 class="category-title">{{title}} {{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}</h5>
-            <ul class="pages">
-              {{#files}}
-                <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
-              {{/files}}
-            </ul>
-          </li>
-        {{/is_index}}
+        <li class="category">
+          {{#is_index}}
+            <h5 class="category-title">Main Articles {{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}</h5>
+          {{/is_index}}
+          {{^is_index}}
+              <h5 class="category-title">{{title}} {{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}</h5>
+          {{/is_index}}
+          <ul class="pages">
+            {{#files}}
+              <li class="page{{#active}} active{{/active}}"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
+            {{/files}}
+          </ul>
+        </li>
       {{/pages}}
     </ul>
 


### PR DESCRIPTION
There are changes to resolve #70

1. Added 'Main articles' header into menu to keep interface consistent
with other categories
1. If category name for page being saved is 'Main articles' then we send
empty category name in request to API
1. If backend API receives empty category name then it creates or
updates file in root of content directory