### PR TITLE
Auth on changes only

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -22,6 +22,11 @@ function initialize (config) {
 
   // New Express App
   var app = express();
+  
+  // empty authorization middleware in case we don't need authentication at all
+  var isAuthenticated = function(req, res, next) {
+        return next();
+      };
 
   // Setup Port
   app.set('port', process.env.PORT || 3000);
@@ -83,12 +88,23 @@ function initialize (config) {
       req.session.loggedIn = false;
       res.redirect("/login");
     });
+    
+    // Authentication Middleware
+    isAuthenticated = function(req, res, next) {
+      if (! req.session.loggedIn) {
+        res.redirect(403, "/login");
+
+        return;
+      }
+
+      return next();
+    }
   }
 
   // Online Editor Routes
   if (config.allow_editing === true) {
 
-    app.post('/rn-edit', function (req, res, next) {
+    app.post('/rn-edit', isAuthenticated, function (req, res, next) {
       var filePath = path.normalize(raneto.config.content_dir + req.body.file);
       if (!fs.existsSync(filePath)) { filePath += '.md'; }
       fs.writeFile(filePath, req.body.content, function (err) {
@@ -106,7 +122,7 @@ function initialize (config) {
       });
     });
 
-    app.post('/rn-delete', function (req, res, next) {
+    app.post('/rn-delete', isAuthenticated, function (req, res, next) {
       var filePath = path.normalize(raneto.config.content_dir + req.body.file);
       if (!fs.existsSync(filePath)) { filePath += '.md'; }
       fs.rename(filePath, filePath + '.del', function (err) {
@@ -124,7 +140,7 @@ function initialize (config) {
       });
     });
 
-    app.post('/rn-add-category', function (req, res, next) {
+    app.post('/rn-add-category', isAuthenticated, function (req, res, next) {
       var filePath = path.normalize(raneto.config.content_dir + req.body.category);
       fs.mkdir(filePath, function (err) {
         if (err) {
@@ -141,7 +157,7 @@ function initialize (config) {
       });
     });
 
-    app.post('/rn-add-page', function (req, res, next) {
+    app.post('/rn-add-page', isAuthenticated, function (req, res, next) {
       var filePath = path.normalize(raneto.config.content_dir + (!!req.body.category ? req.body.category + '/' : '') + req.body.name + '.md');
       fs.open(filePath, 'a', function (err, fd) {
         fs.close(fd);
@@ -163,10 +179,6 @@ function initialize (config) {
 
   // Router for / and /index with or without search parameter
   app.get("/:var(index)?", function(req, res, next){
-    if (config.authentication === true && !req.session.loggedIn) {
-      res.redirect("/login");
-      return;
-    }
     if (req.query.search) {
 
       var searchQuery    = validator.toString(validator.escape(_s.stripTags(req.query.search))).trim();
@@ -178,7 +190,8 @@ function initialize (config) {
         pages: pageListSearch,
         search: searchQuery,
         searchResults: searchResults,
-        body_class: 'page-search'
+        body_class: 'page-search',
+        loggedIn: (req.session.loggedIn)
       });
 
     } else {
@@ -199,16 +212,13 @@ function initialize (config) {
         config        : config,
         pages         : pageList,
         body_class    : 'page-home',
-        last_modified : moment(stat.mtime).format('Do MMM YYYY')
+        last_modified : moment(stat.mtime).format('Do MMM YYYY'),
+        loggedIn      : (req.session.loggedIn)
       });
     }
   });
 
   app.get(/^([^.]*)/, function (req, res, next) {
-    if (config.authentication === true && !req.session.loggedIn) {
-      res.redirect("/login");
-      return;
-    }
     var suffix = 'edit';
 
      if (req.params[0]) {
@@ -227,6 +237,11 @@ function initialize (config) {
       if (filePathOrig.indexOf(suffix, filePathOrig.length - suffix.length) !== -1) {
 
         fs.readFile(filePath, 'utf8', function (err, content) {
+          if (config.authentication === true && ! req.session.loggedIn) {
+            res.redirect("/login");
+            return;
+          }
+
           if (err) {
             err.status = '404';
             err.message = 'Whoops. Looks like this page doesn\'t exist.';
@@ -253,7 +268,8 @@ function initialize (config) {
               meta: meta,
               content: html,
               body_class: template + '-' + raneto.cleanString(slug),
-              last_modified: moment(stat.mtime).format('Do MMM YYYY')
+              last_modified: moment(stat.mtime).format('Do MMM YYYY'),
+              loggedIn: (req.session.loggedIn)
             });
 
           }
@@ -296,7 +312,8 @@ function initialize (config) {
               meta: meta,
               content: html,
               body_class: template + '-' + raneto.cleanString(slug),
-              last_modified: moment(stat.mtime).format('Do MMM YYYY')
+              last_modified: moment(stat.mtime).format('Do MMM YYYY'),
+              loggedIn: (req.session.loggedIn)
             });
 
           }
@@ -315,7 +332,8 @@ function initialize (config) {
       status     : err.status,
       message    : err.message,
       error      : {},
-      body_class : 'page-error'
+      body_class : 'page-error',
+      loggedIn: (req.session.loggedIn)
     });
   });
 

--- a/app/index.js
+++ b/app/index.js
@@ -191,7 +191,7 @@ function initialize (config) {
         search: searchQuery,
         searchResults: searchResults,
         body_class: 'page-search',
-        loggedIn: (req.session.loggedIn)
+        loggedIn: (config.authentication ? req.session.loggedIn : false)
       });
 
     } else {
@@ -213,7 +213,7 @@ function initialize (config) {
         pages         : pageList,
         body_class    : 'page-home',
         last_modified : moment(stat.mtime).format('Do MMM YYYY'),
-        loggedIn      : (req.session.loggedIn)
+        loggedIn: (config.authentication ? req.session.loggedIn : false)
       });
     }
   });
@@ -269,7 +269,7 @@ function initialize (config) {
               content: html,
               body_class: template + '-' + raneto.cleanString(slug),
               last_modified: moment(stat.mtime).format('Do MMM YYYY'),
-              loggedIn: (req.session.loggedIn)
+              loggedIn: (config.authentication ? req.session.loggedIn : false)
             });
 
           }
@@ -313,7 +313,7 @@ function initialize (config) {
               content: html,
               body_class: template + '-' + raneto.cleanString(slug),
               last_modified: moment(stat.mtime).format('Do MMM YYYY'),
-              loggedIn: (req.session.loggedIn)
+              loggedIn: (config.authentication ? req.session.loggedIn : false)
             });
 
           }
@@ -333,7 +333,7 @@ function initialize (config) {
       message    : err.message,
       error      : {},
       body_class : 'page-error',
-      loggedIn: (req.session.loggedIn)
+      loggedIn   : (config.authentication ? req.session.loggedIn : false)
     });
   });
 

--- a/public/scripts/raneto.js
+++ b/public/scripts/raneto.js
@@ -48,6 +48,8 @@
             window.location = [current_category, name, "edit"].join("/");
             break;
         }
+      }).fail(function(data) {
+        if (data.status === 403) window.location = '/login';
       });
     });
 
@@ -62,6 +64,8 @@
             window.location = "/";
             break;
         }
+      }).fail(function(data) {
+        if (data.status === 403) window.location = '/login';
       });
     });
 
@@ -89,7 +93,9 @@
                             .replace(/\s+/g, "-")
         }, function (data) {
           location.reload();
-        });
+        }).fail(function(data) {
+        if (data.status === 403) window.location = '/login';
+      });
       }
     });
 
@@ -128,6 +134,8 @@
             });
             break;
         }
+      }).fail(function(data) {
+        if (data.status === 403) window.location = '/login';
       });
     });
 

--- a/themes/default/templates/layout.html
+++ b/themes/default/templates/layout.html
@@ -29,7 +29,12 @@
         <div class="col-sm-6">
           <form class="form-inline pull-right">
             {{#config.authentication}}
-            &nbsp;<a href="/logout" class="btn btn-info">Logout</a>
+              {{#loggedIn}}
+              &nbsp;<a href="{{config.base_url}}/logout" class="btn btn-info">Logout</a>
+              {{/loggedIn}}
+              {^loggedIn}}
+              &nbsp;<a href="{{config.base_url}}/login" class="btn btn-info">Login</a>
+              {{/loggedIn}}
             {{/config.authentication}}
           </form>
           <form class="search-form form-inline pull-right" action="{{config.base_url}}/">
@@ -58,7 +63,8 @@
   </footer>
 
   {{#config.allow_editing}}
-
+  {{#loggedIn}}
+  
     <!-- Modal: Add Page -->
     <div class="modal fade" id="addModal" tabindex="-1">
       <div class="modal-dialog">
@@ -97,7 +103,8 @@
         </div>
       </div>
     </div>
-
+  
+  {{/loggedIn}}
   {{/config.allow_editing}}
 
   <!-- JavaScript -->

--- a/themes/default/templates/layout.html
+++ b/themes/default/templates/layout.html
@@ -32,7 +32,7 @@
               {{#loggedIn}}
               &nbsp;<a href="{{config.base_url}}/logout" class="btn btn-info">Logout</a>
               {{/loggedIn}}
-              {^loggedIn}}
+              {{^loggedIn}}
               &nbsp;<a href="{{config.base_url}}/login" class="btn btn-info">Login</a>
               {{/loggedIn}}
             {{/config.authentication}}

--- a/themes/default/templates/page.html
+++ b/themes/default/templates/page.html
@@ -3,16 +3,19 @@
   <div class="col-sm-3">
 
     <ul class="menu">
-      {{#config.allow_editing}}
-        <li><input id="newCategory" type="text" class="form-control" placeholder="Add Category"/></li>
-      {{/config.allow_editing}}
+      {{#loggedIn}}
+        {{#config.allow_editing}}
+          <li><input id="newCategory" type="text" class="form-control" placeholder="Add Category"/></li>
+        {{/config.allow_editing}}
+      {{/loggedIn}}
+      
       {{#pages}}
         <li class="category">
           {{#is_index}}
-            <h5 class="category-title">Main Articles {{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}</h5>
+            <h5 class="category-title">Main Articles {{#loggedIn}}{{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}{{/loggedIn}}</h5>
           {{/is_index}}
           {{^is_index}}
-              <h5 class="category-title">{{title}} {{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}</h5>
+              <h5 class="category-title">{{title}} {{#loggedIn}}{{#config.allow_editing}}<a class="add-page" data-toggle="modal" data-target="#addModal"><span style="font-weight: bold; font-size: 16px; cursor:pointer">&#43;</span></a>{{/config.allow_editing}}{{/loggedIn}}</h5>
           {{/is_index}}
           <ul class="pages">
             {{#files}}
@@ -28,6 +31,7 @@
 
     <section class="content">
 
+    {{#loggedIn}}
       {{#config.allow_editing}}
         <div class="btn-group btn-group-sm pull-right">
           <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
@@ -39,6 +43,7 @@
           </ul>
         </div>
       {{/config.allow_editing}}
+    {{/loggedIn}}
 
       {{#meta.title}}<h1 class="title">{{meta.title}}</h1>{{/meta.title}}
 


### PR DESCRIPTION
This would close #77 by enabling authentication only for actions that modify content, like editing, deleting or creating pages and categories.
I also added a fallback redirect for ajax requests in `public/scripts/raneto.js` in case the session is expired or else.
Though it is not possible to keep the current functionality of requiring authentication for each page.