### PR TITLE
Add editorconfig, convert all tabs to spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/app/functions/create_meta_info.js
+++ b/app/functions/create_meta_info.js
@@ -3,24 +3,24 @@
 
 // Returns an empty string if all input strings are empty
 function create_meta_info(meta_title, meta_description, meta_sort) {
-	var newline = '\n';
-	var comment_start = '/*';
-	var comment_end = '*/';
-	var title_label = 'Title: ';
-	var description_label = 'Description: ';
-	var description_sort = 'Sort: ';
+  var newline = '\n';
+  var comment_start = '/*';
+  var comment_end = '*/';
+  var title_label = 'Title: ';
+  var description_label = 'Description: ';
+  var description_sort = 'Sort: ';
 
-	var no_meta_info_is_present = !meta_title && !meta_description && !meta_sort;
-	var meta_header = '';
-	if (!no_meta_info_is_present) {
-		meta_header = comment_start + newline +
-		(meta_title ? title_label + meta_title + newline : '') +
-		(meta_description ? description_label + meta_description + newline : '') +
-		(meta_sort ? description_sort + meta_sort + newline : '') +
-		comment_end + newline + newline;
-	}
+  var no_meta_info_is_present = !meta_title && !meta_description && !meta_sort;
+  var meta_header = '';
+  if (!no_meta_info_is_present) {
+    meta_header = comment_start + newline +
+    (meta_title ? title_label + meta_title + newline : '') +
+    (meta_description ? description_label + meta_description + newline : '') +
+    (meta_sort ? description_sort + meta_sort + newline : '') +
+    comment_end + newline + newline;
+  }
 
-	return meta_header;
+  return meta_header;
 }
 
 // Exports

--- a/themes/default/public/styles/login-style.css
+++ b/themes/default/public/styles/login-style.css
@@ -1,34 +1,34 @@
 
 body {
-    font-family: 'Roboto', sans-serif;
-    font-size: 16px;
-    font-weight: 300;
-    color: #888;
-    line-height: 30px;
-    text-align: center;
+  font-family: 'Roboto', sans-serif;
+  font-size: 16px;
+  font-weight: 300;
+  color: #888;
+  line-height: 30px;
+  text-align: center;
 }
 
 strong { font-weight: 500; }
 
 a, a:hover, a:focus {
-	color: #2C323D;
-	text-decoration: none;
-    -o-transition: all .3s; -moz-transition: all .3s; -webkit-transition: all .3s; -ms-transition: all .3s; transition: all .3s;
+  color: #2C323D;
+  text-decoration: none;
+  -o-transition: all .3s; -moz-transition: all .3s; -webkit-transition: all .3s; -ms-transition: all .3s; transition: all .3s;
 }
 
 h1, h2 {
-	margin-top: 10px;
-	font-size: 38px;
-    font-weight: 100;
-    color: #555;
-    line-height: 50px;
+  margin-top: 10px;
+  font-size: 38px;
+  font-weight: 100;
+  color: #555;
+  line-height: 50px;
 }
 
 h3 {
-	font-size: 22px;
-    font-weight: 300;
-    color: #555;
-    line-height: 30px;
+  font-size: 22px;
+  font-weight: 300;
+  color: #555;
+  line-height: 30px;
 }
 
 img { max-width: 100%; }
@@ -38,16 +38,16 @@ img { max-width: 100%; }
 
 
 .btn-link-1 {
-	display: inline-block;
-	height: 50px;
-	margin: 5px;
-	padding: 16px 20px 0 20px;
-	background: #2C323D;
-	font-size: 16px;
-    font-weight: 300;
-    line-height: 16px;
-    color: #fff;
-    -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
+  display: inline-block;
+  height: 50px;
+  margin: 5px;
+  padding: 16px 20px 0 20px;
+  background: #2C323D;
+  font-size: 16px;
+  font-weight: 300;
+  line-height: 16px;
+  color: #fff;
+  -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
 }
 .btn-link-1:hover, .btn-link-1:focus, .btn-link-1:active { outline: 0; opacity: 0.6; color: #fff; }
 
@@ -56,24 +56,24 @@ img { max-width: 100%; }
 .btn-link-1.btn-link-1-google-plus { background: #dd4b39; }
 
 .btn-link-1 i {
-	padding-right: 5px;
-	vertical-align: middle;
-	font-size: 20px;
-	line-height: 20px;
+  padding-right: 5px;
+  vertical-align: middle;
+  font-size: 20px;
+  line-height: 20px;
 }
 
 .btn-link-2 {
-	display: inline-block;
-	height: 50px;
-	margin: 5px;
-	padding: 15px 20px 0 20px;
-	background: rgba(0, 0, 0, 0.3);
-	border: 1px solid #fff;
-	font-size: 16px;
-    font-weight: 300;
-    line-height: 16px;
-    color: #fff;
-    -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
+  display: inline-block;
+  height: 50px;
+  margin: 5px;
+  padding: 15px 20px 0 20px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #fff;
+  font-size: 16px;
+  font-weight: 300;
+  line-height: 16px;
+  color: #fff;
+  -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
 }
 .btn-link-2:hover, .btn-link-2:focus,
 .btn-link-2:active, .btn-link-2:active:focus { outline: 0; opacity: 0.6; background: rgba(0, 0, 0, 0.3); color: #fff; }
@@ -86,82 +86,82 @@ img { max-width: 100%; }
 }
 
 .top-content .text {
-	color: #fff;
+  color: #fff;
 }
 
 .top-content .text h1 { color: #fff; }
 
 .top-content .description {
-	margin: 20px 0 10px 0;
+  margin: 20px 0 10px 0;
 }
 
 .top-content .description p { opacity: 0.8; }
 
 .top-content .description a {
-	color: #fff;
+  color: #fff;
 }
 .top-content .description a:hover,
 .top-content .description a:focus { border-bottom: 1px dotted #fff; }
 
 .form-box {
-	margin-top: 35px;
+  margin-top: 35px;
 }
 
 .form-top {
-	overflow: hidden;
-	padding: 0 25px 15px 25px;
-	background: #fff;
-	-moz-border-radius: 4px 4px 0 0; -webkit-border-radius: 4px 4px 0 0; border-radius: 4px 4px 0 0;
-	text-align: left;
+  overflow: hidden;
+  padding: 0 25px 15px 25px;
+  background: #fff;
+  -moz-border-radius: 4px 4px 0 0; -webkit-border-radius: 4px 4px 0 0; border-radius: 4px 4px 0 0;
+  text-align: left;
 }
 
 .form-top-left {
-	float: left;
-	width: 75%;
-	padding-top: 25px;
+  float: left;
+  width: 75%;
+  padding-top: 25px;
 }
 
 .form-top-left h3 { margin-top: 0; }
 
 .form-top-right {
-	float: left;
-	width: 25%;
-	padding-top: 5px;
-	font-size: 66px;
-	color: #ddd;
-	line-height: 100px;
-	text-align: right;
+  float: left;
+  width: 25%;
+  padding-top: 5px;
+  font-size: 66px;
+  color: #ddd;
+  line-height: 100px;
+  text-align: right;
 }
 
 .form-bottom {
-	padding: 25px 25px 30px 25px;
-	background: #eee;
-	-moz-border-radius: 0 0 4px 4px; -webkit-border-radius: 0 0 4px 4px; border-radius: 0 0 4px 4px;
-	text-align: left;
+  padding: 25px 25px 30px 25px;
+  background: #eee;
+  -moz-border-radius: 0 0 4px 4px; -webkit-border-radius: 0 0 4px 4px; border-radius: 0 0 4px 4px;
+  text-align: left;
 }
 
 .form-bottom form textarea {
-	height: 100px;
+  height: 100px;
 }
 
 .form-bottom form button.btn {
-	width: 100%;
+  width: 100%;
 }
 
 .form-bottom form .input-error {
-	border-color: #2C323D;
+  border-color: #2C323D;
 }
 
 .social-login {
-	margin-top: 35px;
+  margin-top: 35px;
 }
 
 .social-login h3 {
-	color: #fff;
+  color: #fff;
 }
 
 .social-login-buttons {
-	margin-top: 25px;
+  margin-top: 25px;
 }
 
 
@@ -173,13 +173,13 @@ img { max-width: 100%; }
 
 @media (max-width: 767px) {
 
-	.inner-bg { padding: 60px 0 110px 0; }
+  .inner-bg { padding: 60px 0 110px 0; }
 
 }
 
 @media (max-width: 415px) {
 
-	h1, h2 { font-size: 32px; }
+  h1, h2 { font-size: 32px; }
 
 }
 


### PR DESCRIPTION
This adds an `.editorconfig` to standardise 2-space indenting, and I've gone through and replaced any tab indentation with spaces for non-lib code.

Fix #104 