### PR TITLE
Adds Docker deployment support to Raneto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node
+
+EXPOSE 3000
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+RUN npm install --production && \
+	./node_modules/gulp/bin/gulp.js
+
+CMD ["npm", "start"]


### PR DESCRIPTION
This lets you simply:

```#!bash
docker build -t raneto .
docker run -d -e VIRTUALHOST=kb.mydomain.com -e PORT=3000 raneto
```

The configeration above is only an example and uses
[autodock-paas](https://github.com/prologic/autodock-paas)

Otherwise just: `docker run -d -p 3000:3000 raneto` and hit http://<ip_of_docker_host>:3000/