### PR TITLE
Switch from yamljs to js-yaml in core

### DIFF
--- a/app/raneto-core/lib/raneto.js
+++ b/app/raneto-core/lib/raneto.js
@@ -36,9 +36,9 @@ var _lunr = require('lunr');
 
 var _lunr2 = _interopRequireDefault(_lunr);
 
-var _yamljs = require('yamljs');
+var _jsYaml = require('js-yaml');
 
-var yaml = _interopRequireWildcard(_yamljs);
+var yaml = _interopRequireWildcard(_jsYaml);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -139,7 +139,7 @@ var Raneto = function () {
           metaArr = markdownContent.match(_metaRegexYaml);
           metaString = metaArr ? metaArr[1].trim() : '';
 
-          yamlObject = yaml.parse(metaString);
+          yamlObject = yaml.safeLoad(metaString);
 
           for (yamlField in yamlObject) {
             if (yamlObject.hasOwnProperty(yamlField)) {

--- a/app/raneto-core/package.json
+++ b/app/raneto-core/package.json
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "glob": "7.0.0",
+    "js-yaml": "^3.6.1",
     "lunr": "0.6.0",
     "marked": "0.3.5",
     "moment": "2.11.2",
     "underscore": "1.8.3",
     "underscore.string": "3.2.3",
-    "validator": "4.8.0",
-    "yamljs": "^0.2.7"
+    "validator": "4.8.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/app/raneto-core/src/raneto.js
+++ b/app/raneto-core/src/raneto.js
@@ -5,7 +5,7 @@ import * as _       from 'underscore';
 import * as _s      from 'underscore.string';
 import marked       from 'marked';
 import lunr         from 'lunr';
-import * as yaml    from 'yamljs';
+import * as yaml    from 'js-yaml';
 
 const default_config = {
   // The base URL of your site (allows you to use %base_url% in Markdown files)
@@ -87,7 +87,7 @@ class Raneto {
         metaArr    = markdownContent.match(_metaRegexYaml);
         metaString = metaArr ? metaArr[1].trim() : '';
 
-        yamlObject = yaml.parse(metaString);
+        yamlObject = yaml.safeLoad(metaString);
 
         for (yamlField in yamlObject) {
           if (yamlObject.hasOwnProperty(yamlField)) {

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "sweetalert": "^1.1.3",
     "underscore": "^1.8.3",
     "underscore.string": "^3.3.4",
-    "validator": "^5.6.0",
-    "yamljs": "^0.2.8"
+    "validator": "^5.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
We're already using js-yaml in Raneto, just switching core from yamljs
to js-yaml to remove a dependency.