### PR TITLE
Add support for custom variables

### DIFF
--- a/app/raneto-core/lib/raneto.js
+++ b/app/raneto-core/lib/raneto.js
@@ -175,6 +175,11 @@ var Raneto = function () {
   }, {
     key: 'processVars',
     value: function processVars(markdownContent) {
+      if (typeof this.config.variables !== 'undefined') {
+        this.config.variables.forEach(function (block) {
+          markdownContent = markdownContent.replace(new RegExp('\%' + block.name + '\%', 'g'), block.content);
+        });
+      }
       if (typeof this.config.base_url !== 'undefined') {
         markdownContent = markdownContent.replace(/\%base_url\%/g, this.config.base_url);
       }

--- a/app/raneto-core/src/raneto.js
+++ b/app/raneto-core/src/raneto.js
@@ -117,6 +117,11 @@ class Raneto {
 
   // Replace content variables in Markdown content
   processVars(markdownContent) {
+    if (typeof this.config.variables !== 'undefined') {
+      this.config.variables.forEach(block => {
+        markdownContent = markdownContent.replace(new RegExp('\%'+block.name+'\%', 'g'), block.content);
+      });
+    }
     if (typeof this.config.base_url  !== 'undefined') {
       markdownContent = markdownContent.replace(/\%base_url\%/g, this.config.base_url);
     }

--- a/example/config.default.js
+++ b/example/config.default.js
@@ -87,6 +87,17 @@ var config = {
     //description : 'Custom Home Description'
   },
 
+  //variables: [
+  //  {
+  //    name: 'test_variable',
+  //    content: 'test variable'
+  //  },
+  //  {
+  //    name: 'test_variable_2',
+  //    content: 'test variable 2'
+  //  }
+  //]
+
   table_of_contents: false
 
 };

--- a/test/raneto-core.test.js
+++ b/test/raneto-core.test.js
@@ -135,6 +135,18 @@ describe('#processVars()', function () {
           .should.equal('This is some Markdown with a /base/url.');
   });
 
+  it('replaces custom vars in Markdown content', function () {
+    var variables = [
+      {
+        name: 'test_variable',
+        content: 'Test Variable'
+      }
+    ];
+    raneto.config.variables = variables;
+    raneto.processVars('This is some Markdown with a %test_variable%.')
+          .should.equal('This is some Markdown with a Test Variable.');
+  });
+
 });
 
 describe('#getPage()', function () {


### PR DESCRIPTION
This will replace %variable_name% with Variable Content.
The code will only run if config.variables exists.
The name should not include %'s.
Closes #42