### PR TITLE
Add optional modified yaml

### DIFF
--- a/app/functions/get_last_modified.js
+++ b/app/functions/get_last_modified.js
@@ -1,0 +1,20 @@
+
+'use strict';
+
+// Modules
+var fs     = require('fs');
+var moment = require('moment');
+
+// Returns a formated datetime
+function get_last_modified (config,meta,file_path) {
+
+  if(typeof meta.modified !== 'undefined') {
+    return moment(meta.modified).format(config.datetime_format);
+  } else {
+    return moment(fs.lstatSync(file_path).mtime).format(config.datetime_format);
+  }
+
+}
+
+// Exports
+module.exports = get_last_modified;

--- a/app/routes/home.route.js
+++ b/app/routes/home.route.js
@@ -3,8 +3,8 @@
 
 // Modules
 var fs                             = require('fs');
-var moment                         = require('moment');
 var get_filepath                   = require('../functions/get_filepath.js');
+var get_last_modified              = require('../functions/get_last_modified.js');
 var remove_image_content_directory = require('../functions/remove_image_content_directory.js');
 
 function route_home (config, raneto) {
@@ -33,7 +33,6 @@ function route_home (config, raneto) {
       filename : 'home.html'
     });
 
-    var stat     = fs.lstatSync(template_filepath);
     var pageList = remove_image_content_directory(config, raneto.getPages('/index'));
 
     return res.render('home', {
@@ -41,7 +40,7 @@ function route_home (config, raneto) {
       pages         : pageList,
       body_class    : 'page-home',
       meta          : config.home_meta,
-      last_modified : moment(stat.mtime).format('Do MMM YYYY'),
+      last_modified : get_last_modified(config,config.home_meta,template_filepath),
       lang          : config.lang,
       loggedIn      : ((config.authentication || config.authentication_for_edit) ? req.session.loggedIn : false),
       username      : ((config.authentication || config.authentication_for_edit) ? req.session.username : null)

--- a/app/routes/sitemap.route.js
+++ b/app/routes/sitemap.route.js
@@ -1,11 +1,11 @@
 'use strict';
 
 // Modules
-var path   = require('path');
-var fs     = require('fs');
-var sm     = require('sitemap');
-var _      = require('underscore');
-var moment = require('moment');
+var path              = require('path');
+var fs                = require('fs');
+var sm                = require('sitemap');
+var _                 = require('underscore');
+var get_last_modified = require('../functions/get_last_modified.js');
 
 function route_sitemap(config, raneto) {
   return function (req, res, next) {
@@ -35,12 +35,11 @@ function route_sitemap(config, raneto) {
     });
 
     for (var i = 0, len = urls.length; i < len; i++) {
-      var stat = fs.lstatSync(files[i]);
       sitemap.add({
         url: urls[i],
         changefreq: 'weekly',
         priority: 0.8,
-        lastmod: moment(stat.mtime).format('YYYY-MM-DD')
+        lastmod: get_last_modified(config,meta,files[i])
       });
     }
 

--- a/app/routes/sitemap.route.js
+++ b/app/routes/sitemap.route.js
@@ -35,11 +35,14 @@ function route_sitemap(config, raneto) {
     });
 
     for (var i = 0, len = urls.length; i < len; i++) {
+      var content = fs.readFileSync(files[i],'utf8');
+      // Need to override the datetime format for sitemap
+      var conf = {datetime_format: 'YYYY-MM-DD'};
       sitemap.add({
         url: urls[i],
         changefreq: 'weekly',
         priority: 0.8,
-        lastmod: get_last_modified(config,meta,files[i])
+        lastmod: get_last_modified(conf,raneto.processMeta(content),files[i])
       });
     }
 

--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -4,9 +4,9 @@
 // Modules
 var path                           = require('path');
 var fs                             = require('fs');
-var moment                         = require('moment');
 var marked                         = require('marked');
 var toc                            = require('markdown-toc');
+var get_last_modified              = require('../functions/get_last_modified.js');
 var remove_image_content_directory = require('../functions/remove_image_content_directory.js');
 
 function route_wildcard (config, raneto) {
@@ -39,9 +39,6 @@ function route_wildcard (config, raneto) {
 
       // Process Markdown files
       if (path.extname(file_path) === '.md') {
-
-        // File info
-        var stat = fs.lstatSync(file_path);
 
         // Meta
         var meta = raneto.processMeta(content);
@@ -101,7 +98,7 @@ function route_wildcard (config, raneto) {
           meta          : meta,
           content       : content,
           body_class    : template + '-' + raneto.cleanString(slug),
-          last_modified : moment(stat.mtime).format('Do MMM YYYY'),
+          last_modified : get_last_modified(config,meta,file_path),
           lang          : config.lang,
           loggedIn      : loggedIn,
           username      : (config.authentication ? req.session.username : null),

--- a/example/config.default.js
+++ b/example/config.default.js
@@ -78,6 +78,9 @@ var config = {
 
   locale: 'en',
 
+  // Sets the format for datetime's
+  datetime_format: 'Do MMM YYYY',
+
   // Set to true to render suitable layout for RTL languages
   rtl_layout: false,
 

--- a/example/content/usage/page-meta.md
+++ b/example/content/usage/page-meta.md
@@ -1,0 +1,17 @@
+Title: Meta Block
+Description: This page describes how the Meta information works.
+Modified: 2016-09-16T11:50:00-0500
+---
+
+Each page can contain optional meta data about the page. This is useful when you need the page to have a different
+Title than the file name. The meta data will also let you override the last modified date of the page. The meta data
+should be written in (YAML)[http://www.yaml.org/spec/1.2/spec.html].
+
+ * Title - This variable will override the title based on the file name.
+ * Description - This variable will give lunr a description to search on.
+ * Sort - This variable will affect the sorting of the pages inside the category
+ * Modified - This variable will override the modified date based on the file name.
+   * This should be in full ISO 8601 format including Time and Timezone offset.
+
+Before version 0.11.0 these meta blocks could only be HTML comments (/* */). Starting with version 0.11.0, the meta
+blocks should be YAML blocks.

--- a/example/content/usage/page-meta.md
+++ b/example/content/usage/page-meta.md
@@ -13,5 +13,5 @@ should be written in [YAML](http://www.yaml.org/spec/1.2/spec.html).
  * Modified - This variable will override the modified date based on the file name.
    * This should be in full ISO 8601 format including Time and Timezone offset.
 
-Before version 0.11.0 these meta blocks could only be HTML comments (/* */). Starting with version 0.11.0, the meta
+Before version 0.11.0 these meta blocks could only be HTML comments (/\* \*/). Starting with version 0.11.0, the meta
 blocks should be YAML blocks.

--- a/example/content/usage/page-meta.md
+++ b/example/content/usage/page-meta.md
@@ -1,11 +1,11 @@
 Title: Meta Block
 Description: This page describes how the Meta information works.
-Modified: 2016-09-16T11:50:00-0500
+Modified: 2016-09-14T11:50:00-0500
 ---
 
 Each page can contain optional meta data about the page. This is useful when you need the page to have a different
 Title than the file name. The meta data will also let you override the last modified date of the page. The meta data
-should be written in (YAML)[http://www.yaml.org/spec/1.2/spec.html].
+should be written in [YAML](http://www.yaml.org/spec/1.2/spec.html).
 
  * Title - This variable will override the title based on the file name.
  * Description - This variable will give lunr a description to search on.

--- a/test/content/page-with-bom-yaml.md
+++ b/test/content/page-with-bom-yaml.md
@@ -1,5 +1,6 @@
 ﻿Title: Example Page With BOM for YAML
 Sort: 3
+Modified: 2016-09-14T15:43:00-0500
 ---
 
 This is some example content if a file that has a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) character.

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/*jshint expr: true*/
+
+// Modules
+var fs                = require('fs');
+var path              = require('path');
+var chai              = require('chai');
+var expect            = chai.expect;
+var moment            = require('moment');
+var raneto            = require('../app/core/lib/raneto.js');
+var get_last_modified = require('../app/functions/get_last_modified.js');
+
+chai.should();
+chai.config.truncateThreshold = 0;
+
+describe('#get_last_modified()', function () {
+
+  it('returns last modified from page meta', function () {
+    raneto.config.datetime_format = 'Do MMM YYYY';
+    var file_path = path.join(__dirname, 'content/page-with-bom-yaml.md');
+    var content = fs.readFileSync(file_path,'utf8');
+    var modified = get_last_modified(raneto.config,raneto.processMeta(content),file_path);
+    expect(modified).to.be.equal('14th Sep 2016');
+  });
+
+  it('returns last modified from fs', function() {
+    raneto.config.datetime_format = 'Do MMM YYYY';
+    var file_path = path.join(__dirname, 'content/example-page.md');
+    var content = fs.readFileSync(file_path,'utf8');
+    var modified = get_last_modified(raneto.config,raneto.processMeta(content),file_path);
+    var fstime = moment(fs.lstatSync(file_path).mtime).format(raneto.config.datetime_format);
+    expect(modified).to.be.equal(fstime);
+  });
+
+});
+


### PR DESCRIPTION
This gives us the ability to override the file system's last modified date by adding an optional `Modified:` yaml variable. According to the (YAML spec)[http://yaml.org/type/timestamp.html], the datetime should be an ISO 8601 datetime.

This also requires a time (with timezone offset) attached to it. The reason why is because YAML interprets a date with no time as 00:00:00-0000. That means that when the datetime is loaded, it could select the previous day as the date. ie: 2010-01-01 gives us 2010-01-01T00:00:00-0000, which when converted into a datetime with YAML, then gives us 2009-12-31T19:00:00-0500.

Closes #69.