### PR TITLE
Fix meta header to prevent broken tables

### DIFF
--- a/app/functions/create_meta_info.js
+++ b/app/functions/create_meta_info.js
@@ -15,7 +15,7 @@ function create_meta_info (meta_title, meta_description, meta_sort) {
     if (meta_description) { yamlDocument.Description = meta_description;        }
     if (meta_sort)        { yamlDocument.Sort        = parseInt(meta_sort, 10); }
 
-    return yaml.safeDump(yamlDocument) + '---\n';
+    return '/*\n' + yaml.safeDump(yamlDocument) + '*/\n';
   } else {
     return '';
   }


### PR DESCRIPTION
Changed meta header to be wrapped in /* */. --- appears to break tables when editing through web interface.