### PR TITLE
Making sitemaps works properly on unix based systems.

### DIFF
--- a/app/routes/sitemap.route.js
+++ b/app/routes/sitemap.route.js
@@ -16,7 +16,7 @@ function route_sitemap(config, raneto) {
     // get list md files
     var files = listFiles(content_dir);
     files = _.filter(files, function (file) {
-      return file.endsWith('.md');
+      return file.substr(-3) === '.md';
     });
 
     var filesPath = files.map(function (file) {


### PR DESCRIPTION
It was giving a ".endsWith is not defined" for the file path string, so I went back to simple js and it just worked for CentOS 6.3