### PR TITLE
Fixed #141 where not all markdown files are displayed if they h…

### DIFF
--- a/app/core/lib/raneto.js
+++ b/app/core/lib/raneto.js
@@ -66,8 +66,16 @@ var default_config = {
 };
 
 // Regex for page meta (considers Byte Order Mark \uFEFF in case there's one)
+// Look for the the following header formats at the beginning of the file: 
+// /* 
+// {header string} 
+// */ 
+//   or 
+// --- 
+// {header string} 
+// ---
 var _metaRegex = /^\uFEFF?\/\*([\s\S]*?)\*\//i;
-var _metaRegexYaml = /\uFEFF?\s*([^]*?)(---)/i;
+var _metaRegexYaml = /^\uFEFF?---([\s\S]*?)---/i;
 
 function patch_content_dir(content_dir) {
   return content_dir.replace(/\\/g, '/');

--- a/app/core/src/raneto.js
+++ b/app/core/src/raneto.js
@@ -27,8 +27,16 @@ const default_config = {
 };
 
 // Regex for page meta (considers Byte Order Mark \uFEFF in case there's one)
+// Look for the the following header formats at the beginning of the file: 
+// /* 
+// {header string} 
+// */ 
+//   or 
+// --- 
+// {header string} 
+// ---
 const _metaRegex = /^\uFEFF?\/\*([\s\S]*?)\*\//i;
-const _metaRegexYaml = /\uFEFF?\s*([^]*)---/i;
+const _metaRegexYaml = /^\uFEFF?---([\s\S]*?)---/i;
 
 function patch_content_dir(content_dir) {
   return content_dir.replace(/\\/g, '/');

--- a/app/functions/create_meta_info.js
+++ b/app/functions/create_meta_info.js
@@ -15,9 +15,9 @@ function create_meta_info (meta_title, meta_description, meta_sort) {
     if (meta_description) { yamlDocument.Description = meta_description;        }
     if (meta_sort)        { yamlDocument.Sort        = parseInt(meta_sort, 10); }
 
-    return yaml.safeDump(yamlDocument) + '---\n';
+    return '---\n' + yaml.safeDump(yamlDocument) + '---\n';
   } else {
-    return '---\n';
+    return '---\n---\n';
   }
 
 }

--- a/test/content/page-with-bom-yaml.md
+++ b/test/content/page-with-bom-yaml.md
@@ -1,4 +1,5 @@
-﻿Title: Example Page With BOM for YAML
+﻿---
+Title: Example Page With BOM for YAML
 Sort: 3
 ---
 

--- a/test/raneto-core.test.js
+++ b/test/raneto-core.test.js
@@ -74,7 +74,7 @@ describe('#processMeta()', function () {
   });
 
   it('returns array of meta values (YAML)', function () {
-    var result = raneto.processMeta('\n'+
+    var result = raneto.processMeta('---\n'+
       'Title: This is a title\n'+
       'Description: This is a description\n'+
       'Sort: 4\n'+
@@ -106,9 +106,22 @@ describe('#stripMeta()', function () {
     result.should.equal('This is the content');
   });
 
+  it('strips yaml meta comment block with horizontal rule in content', function() {
+    var result = raneto.stripMeta('---\n'+
+      'Title: + This is a title\n'+
+      '---\n'+
+      'This is the content\n---');
+    result.should.equal('This is the content\n---');
+  });
+
   it('leaves content if no meta comment block', function () {
     var result = raneto.stripMeta('This is the content');
     result.should.equal('This is the content');
+  });
+
+  it('leaves content with horizontal rule if no meta comment block', function () {
+    var result = raneto.stripMeta('This is the content\n---');
+    result.should.equal('This is the content\n---');
   });
 
   it('only strips the first comment block', function () {


### PR DESCRIPTION
…ave 3 dashes (---) in the content, but no metadata header. This change modifies the metadata regex to check for metadata data headers of the following types at the beginning of the file: /* {header} */ or --- {header} ---. Updated tests.

Also fixed issue with metadata being added as: {header} ---, which is an incorrect format for yaml header in markdown files. This change modifies it to insert the header as: --- {header} ---.

The previous way of adding metadata creates several conflicts when trying to parse valid markdown (horizontal rules, tables, code blocks) when no metadata header is actually present.