### PR TITLE
Build nested pages from content directory

### DIFF
--- a/app/core/lib/raneto.js
+++ b/app/core/lib/raneto.js
@@ -66,13 +66,13 @@ var default_config = {
 };
 
 // Regex for page meta (considers Byte Order Mark \uFEFF in case there's one)
-// Look for the the following header formats at the beginning of the file: 
-// /* 
-// {header string} 
-// */ 
-//   or 
-// --- 
-// {header string} 
+// Look for the the following header formats at the beginning of the file:
+// /*
+// {header string}
+// */
+//   or
+// ---
+// {header string}
 // ---
 var _metaRegex = /^\uFEFF?\/\*([\s\S]*?)\*\//i;
 var _metaRegexYaml = /^\uFEFF?---([\s\S]*?)---/i;
@@ -305,6 +305,7 @@ var Raneto = function () {
             slug: shortPath,
             title: dirMetadata.title || _s.titleize(_s.humanize(path.basename(shortPath))),
             is_index: false,
+            is_directory: true,
             class: 'category-' + _this2.cleanString(shortPath),
             sort: dirMetadata.sort || sort,
             files: []
@@ -313,35 +314,34 @@ var Raneto = function () {
 
         if (stat.isFile() && path.extname(shortPath) === '.md') {
           try {
-            (function () {
 
-              var file = fs.readFileSync(filePath);
-              var slug = shortPath;
-              var pageSort = 0;
+            var file = fs.readFileSync(filePath);
+            var slug = shortPath;
+            var pageSort = 0;
 
-              if (shortPath.indexOf('index.md') > -1) {
-                slug = slug.replace('index.md', '');
-              }
+            if (shortPath.indexOf('index.md') > -1) {
+              slug = slug.replace('index.md', '');
+            }
 
-              slug = slug.replace('.md', '').trim();
+            slug = slug.replace('.md', '').trim();
 
-              var dir = path.dirname(shortPath);
-              var meta = _this2.processMeta(file.toString('utf-8'));
+            var dir = path.dirname(shortPath);
+            var meta = _this2.processMeta(file.toString('utf-8'));
 
-              if (page_sort_meta && meta[page_sort_meta]) {
-                pageSort = parseInt(meta[page_sort_meta], 10);
-              }
+            if (page_sort_meta && meta[page_sort_meta]) {
+              pageSort = parseInt(meta[page_sort_meta], 10);
+            }
 
-              var val = _.find(filesProcessed, function (item) {
-                return item.slug === dir;
-              });
-              val.files.push({
-                slug: slug,
-                title: meta.title ? meta.title : _this2.slugToTitle(slug),
-                active: activePageSlug.trim() === '/' + slug,
-                sort: pageSort
-              });
-            })();
+            var val = _.find(filesProcessed, function (item) {
+              return item.slug === dir;
+            });
+            val.files.push({
+              slug: slug,
+              title: meta.title ? meta.title : _this2.slugToTitle(slug),
+              is_directory: false,
+              active: activePageSlug.trim() === '/' + slug,
+              sort: pageSort
+            });
           } catch (e) {
             if (_this2.config.debug) {
               console.log(e);

--- a/app/core/src/raneto.js
+++ b/app/core/src/raneto.js
@@ -27,13 +27,13 @@ const default_config = {
 };
 
 // Regex for page meta (considers Byte Order Mark \uFEFF in case there's one)
-// Look for the the following header formats at the beginning of the file: 
-// /* 
-// {header string} 
-// */ 
-//   or 
-// --- 
-// {header string} 
+// Look for the the following header formats at the beginning of the file:
+// /*
+// {header string}
+// */
+//   or
+// ---
+// {header string}
 // ---
 const _metaRegex = /^\uFEFF?\/\*([\s\S]*?)\*\//i;
 const _metaRegexYaml = /^\uFEFF?---([\s\S]*?)---/i;
@@ -230,6 +230,7 @@ class Raneto {
           slug     : shortPath,
           title    : dirMetadata.title || _s.titleize(_s.humanize(path.basename(shortPath))),
           is_index : false,
+          is_directory: true,
           class    : 'category-' + this.cleanString(shortPath),
           sort     : dirMetadata.sort || sort,
           files    : []
@@ -261,6 +262,7 @@ class Raneto {
           val.files.push({
             slug   : slug,
             title  : meta.title ? meta.title : this.slugToTitle(slug),
+            is_directory: false,
             active : (activePageSlug.trim() === '/'+ slug),
             sort   : pageSort
           });

--- a/app/functions/build_nested_pages.js
+++ b/app/functions/build_nested_pages.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function build_nested_pages (pages) {
+  var result = [];
+  var i = pages.length;
+
+  while(i--) {
+    if (pages[i].slug.split('/').length > 1) {
+      var parent = find_by_slug(pages, pages[i]);
+      parent.files.unshift(pages[i]);
+    } else {
+      result.unshift(pages[i]);
+    }
+  }
+
+  return result;
+}
+
+function find_by_slug (pages, page) {
+  return pages.find(function (element) {
+    return element.slug === page.slug.split('/').slice(0, -1).join('/');
+  });
+}
+
+// Exports
+module.exports = build_nested_pages;

--- a/app/routes/home.route.js
+++ b/app/routes/home.route.js
@@ -3,6 +3,7 @@
 
 // Modules
 var fs                             = require('fs');
+var build_nested_pages             = require('../functions/build_nested_pages.js');
 var get_filepath                   = require('../functions/get_filepath.js');
 var get_last_modified              = require('../functions/get_last_modified.js');
 var remove_image_content_directory = require('../functions/remove_image_content_directory.js');
@@ -37,7 +38,7 @@ function route_home (config, raneto) {
 
     return res.render('home', {
       config        : config,
-      pages         : pageList,
+      pages         : build_nested_pages(pageList),
       body_class    : 'page-home',
       meta          : config.home_meta,
       last_modified : get_last_modified(config,config.home_meta,template_filepath),

--- a/test/content/sub/sub2/sub2_page.md
+++ b/test/content/sub/sub2/sub2_page.md
@@ -1,0 +1,5 @@
+/*
+Title: Sub2 Page
+*/
+
+This is some content.

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -3,13 +3,14 @@
 /*jshint expr: true*/
 
 // Modules
-var fs                = require('fs');
-var path              = require('path');
-var chai              = require('chai');
-var expect            = chai.expect;
-var moment            = require('moment');
-var raneto            = require('../app/core/lib/raneto.js');
-var get_last_modified = require('../app/functions/get_last_modified.js');
+var fs                 = require('fs');
+var path               = require('path');
+var chai               = require('chai');
+var expect             = chai.expect;
+var moment             = require('moment');
+var raneto             = require('../app/core/lib/raneto.js');
+var build_nested_pages = require('../app/functions/build_nested_pages.js');
+var get_last_modified  = require('../app/functions/get_last_modified.js');
 
 chai.should();
 chai.config.truncateThreshold = 0;
@@ -35,3 +36,16 @@ describe('#get_last_modified()', function () {
 
 });
 
+describe('#build_nested_pages()', function () {
+
+  it('builds tree of pages', function () {
+    raneto.config.content_dir = path.join(__dirname, 'content/');
+    var pages = raneto.getPages();
+    var result = build_nested_pages(pages);
+
+    expect(result.length).to.be.equal(2);
+    expect(result[1].files.length).to.be.equal(2);
+    expect(result[1].files[0].files[0].title).to.be.equal('Sub2 Page');
+  });
+
+});

--- a/themes/default/templates/home.html
+++ b/themes/default/templates/home.html
@@ -1,4 +1,3 @@
-
 <div class="home-search jumbotron row">
   <form class="search-form form-inline" action="{{config.base_url}}/">
     <div class="form-group">
@@ -31,7 +30,28 @@
           <h2 class="panel-heading">{{title}}</h2>
           <ul class="list-group pages">
             {{#files}}
-              <li class="list-group-item page"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
+              {{^is_directory}}
+                <li class="list-group-item page"><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
+              {{/is_directory}}
+              {{#is_directory}}
+                <li class="list-group-item page">{{title}}
+                  {{#files}}
+                    <ul>
+                      {{^is_directory}}
+                        <li><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
+                      {{/is_directory}}
+                      {{#is_directory}}
+                        <li>{{title}}</li>
+                        <ul>
+                          {{#files}}
+                            <li><a href="{{config.base_url}}/{{slug}}">{{title}}</a></li>
+                          {{/files}}
+                        </ul>
+                      {{/is_directory}}
+                    </ul>
+                  {{/files}}
+                </li>
+              {{/is_directory}}
             {{/files}}
           </ul>
         </div>


### PR DESCRIPTION
I needed to group the content on the Raneto main page and I created a function to modify pages array for home route. For this I've added a flag (`is_directory`) for new page objects and modified home template so it renders correctly. 

This will also allow to create nice navigation tree menu in the navbar. Something like that was mentioned in #166.

Maybe it should be configurable and what method of showing content should be default then?

Here is example of the results:
<img width="539" alt="raneto_home_page" src="https://cloud.githubusercontent.com/assets/7894868/23608498/ead58e98-0269-11e7-9075-d3446ce81076.png">
