### PR TITLE
Fixes search with special characters

### DIFF
--- a/app/routes/search.route.js
+++ b/app/routes/search.route.js
@@ -19,7 +19,7 @@ function route_search (config, raneto) {
     var invalidChars   = '&\'"/';
     var sanitizedQuery = validator.blacklist(tagFreeQuery, invalidChars);
 
-    // trim and 
+    // trim and convert to string
     var searchQuery    = validator.toString(sanitizedQuery).trim();
 
     var searchResults  = raneto.doSearch(searchQuery);

--- a/app/routes/search.route.js
+++ b/app/routes/search.route.js
@@ -12,7 +12,16 @@ function route_search (config, raneto) {
     // Skip if Search not present
     if (!req.query.search) { return next(); }
 
-    var searchQuery    = validator.toString(validator.escape(_s.stripTags(req.query.search))).trim();
+    // remove < and >
+    var tagFreeQuery   = _s.stripTags(req.query.search);
+
+    // remove /, ', " and & from query 
+    var invalidChars   = '&\'"/';
+    var sanitizedQuery = validator.blacklist(tagFreeQuery, invalidChars);
+
+    // trim and 
+    var searchQuery    = validator.toString(sanitizedQuery).trim();
+
     var searchResults  = raneto.doSearch(searchQuery);
     var pageListSearch = remove_image_content_directory(config, raneto.getPages(''));
 

--- a/test/content/special-chars.md
+++ b/test/content/special-chars.md
@@ -1,0 +1,6 @@
+/*
+Title: Special Characters Page
+Sort: 2
+*/
+
+This is some example content with "special characters".

--- a/test/raneto-core.test.js
+++ b/test/raneto-core.test.js
@@ -219,8 +219,8 @@ describe('#getPages()', function () {
 
   it('loads meta show_on_home value from file', function () {
     raneto.config.content_dir = path.join(__dirname, 'content/');
-    var result = raneto.getPages();    
-    expect(result[0].files[3]).to.have.property('show_on_home', false);
+    var result = raneto.getPages();
+    expect(result[0].files[4]).to.have.property('show_on_home', false);
   });
 
   it('applies show_on_home_default in absence of meta for directories', function () {
@@ -251,13 +251,19 @@ describe('#doSearch()', function () {
   it('returns an array of search results', function () {
     raneto.config.content_dir = path.join(__dirname, 'content/');
     var result = raneto.doSearch('example');
-    expect(result).to.have.length(4);
+    expect(result).to.have.length(5);
   });
 
   it('returns an empty array if nothing found', function () {
     raneto.config.content_dir = path.join(__dirname, 'content/');
     var result = raneto.doSearch('asdasdasd');
     expect(result).to.be.empty;
+  });
+
+  it('returns an array if search has special characters', function () {
+    raneto.config.content_dir = path.join(__dirname, 'content/');
+    var result = raneto.doSearch('with "special');
+    expect(result[0].title).to.be.deep.equals('Special Characters Page');
   });
 
 });


### PR DESCRIPTION
This PR fixes #215, I changed from `validator.escape`, which encoded some special characters and that was breaking the search. This problem could be fixed in two ways: allowing searches with special characters or stripping them from the query. I choose the latter one, since that wouldn't not send the characters to Lunr.