### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ gulp.task('copy_libs', function () {
     'node_modules/highlightjs/**/*',
     'node_modules/jquery/**/*',
     'node_modules/masonry-layout/**/*',
-    'node_modules/sweetalert/**/*',
+    'node_modules/sweetalert2/**/*',
     'node_modules/jquery.backstretch/**/*',
   ];
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "sanitize-filename": "^1.6.1",
     "serve-favicon": "^2.4.5",
     "sitemap": "^1.13.0",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^7.0.9",
     "underscore": "^1.8.3",
     "underscore.string": "^3.3.4",
     "validator": "^9.0.0"

--- a/themes/default/templates/login.html
+++ b/themes/default/templates/login.html
@@ -13,7 +13,6 @@
     <link rel="stylesheet" href="{{config.base_url}}/styles/raneto.css">
     <link rel="stylesheet" href="{{config.base_url}}/styles/login-form.css">
     <link rel="stylesheet" href="{{config.base_url}}/styles/login-style.css">
-    <link rel="stylesheet" href="{{config.base_url}}/lib/sweetalert/dist/sweetalert.css"> 
     <link rel="stylesheet" href="{{config.base_url}}/styles/zocial.css">
     {{#rtl_layout}}
     <link rel="stylesheet" href="{{config.base_url}}/styles/raneto.rtl.css">
@@ -34,7 +33,7 @@
                         <img src="{{config.base_url}}/favicon.ico"></i>
                     </div>
                 </div>
-                
+
                 <div class="form-bottom">
                     {{#googleoauth}}
                       <a href="/auth/login" class="zocial google">Sign in with Google</a>
@@ -69,7 +68,7 @@
     <script src="{{config.base_url}}/lib/jquery/dist/jquery.min.js"></script>
     <script src="{{config.base_url}}/lib/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="{{config.base_url}}/lib/jquery.backstretch/jquery.backstretch.min.js"></script>
-    <script src="{{config.base_url}}/lib/sweetalert/dist/sweetalert.min.js"></script>
+    <script src="{{config.base_url}}/lib/sweetalert2/dist/sweetalert2.all.min.js"></script>
     <script src="{{config.base_url}}/scripts/login.js"></script>
     <script>
     $(document).ready(function() {


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is the inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. No need to care about styles, they are injected automatically  

2. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

3. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

4. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

5. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)

  