### PR TITLE
Search result displays page-excerpt as link when it is a "Main Article" 

### DIFF
--- a/themes/default/templates/search.html
+++ b/themes/default/templates/search.html
@@ -30,7 +30,12 @@
       {{#searchResults.length}}
         {{#searchResults}}
           <div class="page">
-            <h2 class="page-title"><a href="{{config.base_url}}/{{slug}}">{{title}} {{#category}}<span style="color: #DDD;">({{category}})</a>{{/category}}</h2>
+            <h2 class="page-title">
+              <a href="{{config.base_url}}/{{slug}}">
+                {{title}} 
+                {{#category}}<span style="color: #DDD;">({{category}})</span>{{/category}}
+              </a>
+            </h2>
             <div class="page-excerpt">{{{excerpt}}}</div>
           </div>
         {{/searchResults}}


### PR DESCRIPTION
When file is a the root of the content, it displays under the Main Article section.
A search that returns one of those files shows the page excerpt as blue text that is a link.

When the artilce is at the root, it doesn't have a category.
The <a> tag is started unconditionally, but the the end </a> tag is only there when there is a category.
I've formatted the code to better see the conditions as well as fix the issue.