### PR TITLE
Correctly use 404 error.html template when necessary. Don't throw 404 for pages that actually exist. (fixes #264 and #265)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -129,7 +129,7 @@ function initialize (config) {
   }
 
   // Handle Errors
-  app.use(error_handler);
+  router.use(error_handler);
   app.use(config.prefix_url || '/', router);
 
   return app;

--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -23,7 +23,8 @@ function route_wildcard (config) {
     var slug   = req.params[0];
     if (slug === '/') { slug = '/index'; }
 
-    var file_path      = path.normalize(config.content_dir + slug);
+    // Normalize and strip trailing slash
+    var file_path      = path.normalize(config.content_dir + slug).replace(/\/$|\\$/g, '');
     var file_path_orig = file_path;
 
     // Remove "/edit" suffix


### PR DESCRIPTION
Fixes #264 and #265.