### PR TITLE
Fully functional keywords

### DIFF
--- a/app/functions/contentProcessors.js
+++ b/app/functions/contentProcessors.js
@@ -92,6 +92,9 @@ function processMeta (markdownContent) {
     // No meta information
   }
 
+  //extracting keywords from meta into tags table to allow links on them //added by pilare
+  if (meta.keywords) meta.tags = meta.keywords.split(", ");
+  
   return meta;
 }
 

--- a/app/functions/contentProcessors.js
+++ b/app/functions/contentProcessors.js
@@ -92,9 +92,9 @@ function processMeta (markdownContent) {
     // No meta information
   }
 
-  //extracting keywords from meta into tags table to allow links on them //added by pilare
-  if (meta.keywords) meta.tags = meta.keywords.split(", ");
-  
+  // Extracting keywords from meta into tags table to allow links on them. Added by pilare
+  if (meta.keywords) meta.tags = meta.keywords.split(', ');
+
   return meta;
 }
 

--- a/app/functions/create_meta_info.js
+++ b/app/functions/create_meta_info.js
@@ -5,7 +5,7 @@
 var yaml = require('js-yaml');
 
 // Returns an empty string if all input strings are empty
-function create_meta_info (meta_title, meta_description, meta_sort,meta_category,meta_keywords,meta_show_on_home) {
+function create_meta_info (meta_title, meta_description, meta_sort, meta_category, meta_keywords, meta_show_on_home) {
 
   var yamlDocument = {};
   var meta_info_is_present = meta_title || meta_description || meta_sort || meta_category || meta_keywords || meta_show_on_home;
@@ -15,8 +15,8 @@ function create_meta_info (meta_title, meta_description, meta_sort,meta_category
     if (meta_description) { yamlDocument.Description = meta_description;        }
     if (meta_sort)        { yamlDocument.Sort        = parseInt(meta_sort, 10); }
     if (meta_category)    { yamlDocument.Category = meta_category;              }
-    if (meta_keywords)    { yamlDocument.Keywords = meta_keywords;              }    
-    if (meta_show_on_home) { yamlDocument.ShowOnHome = meta_show_on_home;        }
+    if (meta_keywords)    { yamlDocument.Keywords = meta_keywords;              }
+    if (meta_show_on_home) { yamlDocument.ShowOnHome = meta_show_on_home;       }
 
     return '---\n' + yaml.safeDump(yamlDocument) + '---\n';
   } else {

--- a/app/functions/create_meta_info.js
+++ b/app/functions/create_meta_info.js
@@ -5,15 +5,18 @@
 var yaml = require('js-yaml');
 
 // Returns an empty string if all input strings are empty
-function create_meta_info (meta_title, meta_description, meta_sort) {
+function create_meta_info (meta_title, meta_description, meta_sort,meta_category,meta_keywords,meta_show_on_home) {
 
   var yamlDocument = {};
-  var meta_info_is_present = meta_title || meta_description || meta_sort;
+  var meta_info_is_present = meta_title || meta_description || meta_sort || meta_category || meta_keywords || meta_show_on_home;
 
   if (meta_info_is_present) {
     if (meta_title)       { yamlDocument.Title       = meta_title;              }
     if (meta_description) { yamlDocument.Description = meta_description;        }
     if (meta_sort)        { yamlDocument.Sort        = parseInt(meta_sort, 10); }
+    if (meta_category)    { yamlDocument.Category = meta_category;              }
+    if (meta_keywords)    { yamlDocument.Keywords = meta_keywords;              }    
+    if (meta_show_on_home) { yamlDocument.ShowOnHome = meta_show_on_home;        }
 
     return '---\n' + yaml.safeDump(yamlDocument) + '---\n';
   } else {

--- a/app/routes/page.edit.route.js
+++ b/app/routes/page.edit.route.js
@@ -36,7 +36,7 @@ function route_page_edit (config) {
 
     // Create content including meta information (i.e. title, description, sort)
     function create_content (body) {
-      var meta = create_meta_info(body.meta_title, body.meta_description, body.meta_sort,body.meta_category,body.meta_keywords,body.meta_show_on_home);
+      var meta = create_meta_info(body.meta_title, body.meta_description, body.meta_sort, body.meta_category, body.meta_keywords, body.meta_show_on_home);
       return meta + body.content;
     }
 

--- a/app/routes/page.edit.route.js
+++ b/app/routes/page.edit.route.js
@@ -36,7 +36,6 @@ function route_page_edit (config) {
 
     // Create content including meta information (i.e. title, description, sort)
     function create_content (body) {
-      console.log(body);
       var meta = create_meta_info(body.meta_title, body.meta_description, body.meta_sort,body.meta_category,body.meta_keywords,body.meta_show_on_home);
       return meta + body.content;
     }

--- a/app/routes/page.edit.route.js
+++ b/app/routes/page.edit.route.js
@@ -36,7 +36,8 @@ function route_page_edit (config) {
 
     // Create content including meta information (i.e. title, description, sort)
     function create_content (body) {
-      var meta = create_meta_info(body.meta_title, body.meta_description, body.meta_sort);
+      console.log(body);
+      var meta = create_meta_info(body.meta_title, body.meta_description, body.meta_sort,body.meta_category,body.meta_keywords,body.meta_show_on_home);
       return meta + body.content;
     }
 

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -36,6 +36,9 @@
     "headerMetaInfo" : "Meta information",
     "lableMetaTitle": "Title",
     "lableMetaDescription": "Description",
+    "lableMetaCategory": "Category",
+    "lableMetaKeywords": "Keywords",
+    "lableMetaShowOnHome": "Show on home page",
     "lableMetaSort": "Sort"
   },
 

--- a/example/content/usage/page-meta.md
+++ b/example/content/usage/page-meta.md
@@ -2,6 +2,8 @@
 Title: Page Meta
 Description: This page describes how the Meta information works.
 Modified: 2016-09-14T11:50:00-0500
+Keywords: Meta, Metadata, YAML
+Category: Usage
 ---
 
 Each page can contain optional meta data about the page. This is useful when you need the page to have a different
@@ -13,6 +15,8 @@ should be written in [YAML](http://www.yaml.org/spec/1.2/spec.html).
  * Sort - This variable will affect the sorting of the pages inside the category.
  * ShowOnHome - Optional. If false, page won't be listed on the home page. Default behavior can be changed through `config.show_on_home_default`.
  * Modified - This variable will override the modified date based on the file name.
+ * Keywords - This variable will add keywords to the pages that can be displayed and linked out.
+ * Category - This variable will add category of the article to be displayed.
    * This should be in full ISO 8601 format including Time and Timezone offset.
 
 Before version 0.11.0 these meta blocks could only be HTML comments (/\* \*/). Starting with version 0.11.0, the meta

--- a/example/content/usage/page-meta.md
+++ b/example/content/usage/page-meta.md
@@ -1,11 +1,10 @@
 ---
 Title: Page Meta
 Description: This page describes how the Meta information works.
-Modified: 2016-09-14T11:50:00-0500
-Keywords: Meta, Metadata, YAML
 Category: Usage
+Keywords: 'Meta, Metadata, YAML, keyword, tag'
+ShowOnHome: 'true'
 ---
-
 Each page can contain optional meta data about the page. This is useful when you need the page to have a different
 Title than the file name. The meta data will also let you override the last modified date of the page. The meta data
 should be written in [YAML](http://www.yaml.org/spec/1.2/spec.html).

--- a/themes/default/public/scripts/raneto.js
+++ b/themes/default/public/scripts/raneto.js
@@ -127,7 +127,10 @@
           content : $("#entry-markdown").val(),
           meta_title : $("#entry-metainfo-title").val(),
           meta_description : $("#entry-metainfo-description").val(),  
+          meta_category : $("#entry-metainfo-category").val(),  
+          meta_keywords : $("#entry-metainfo-keywords").val(), 
           meta_sort : $("#entry-metainfo-sort").val(),  
+          meta_show_on_home : $("#entry-metainfo-show-on-home").val(),
         }, function (data) {
           switch (data.status) {
             case 0:

--- a/themes/default/templates/edit.html
+++ b/themes/default/templates/edit.html
@@ -44,11 +44,30 @@
                   </div>
                 </div>
                 <div class="form-group">
+                  <label for="entry-metainfo-title" class="control-label col-sm-3">{{lang.edit.lableMetaCategory}}</label>
+                  <div class="col-sm-9">
+                    <input id="entry-metainfo-category" type="text" value="{{{meta.category}}}" class="form-control"></input>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label for="entry-metainfo-title" class="control-label col-sm-3">{{lang.edit.lableMetaKeywords}}</label>
+                  <div class="col-sm-9">
+                    <input id="entry-metainfo-keywords" type="text" value="{{{meta.keywords}}}" class="form-control"></input>
+                  </div>
+                </div>
+                <div class="form-group">
                   <label for="entry-metainfo-title" class="control-label col-sm-3">{{lang.edit.lableMetaSort}}</label>
                   <div class="col-sm-9">
                     <input id="entry-metainfo-sort" type="number" value="{{{meta.sort}}}" class="form-control"></input>
                   </div>
                 </div>
+                <div class="form-group">
+                  <label for="entry-metainfo-title" class="control-label col-sm-3">{{lang.edit.lableMetaShowOnHome}}</label>
+                  <div class="col-sm-9">
+                    <!-- <input id="entry-metainfo-sort" type="checkbox" checked="{{{meta.show_on_home}}}"></input> -->
+                    <input id="entry-metainfo-show-on-home" type="text" value="{{{meta.show_on_home}}}" class="form-control"></input>
+                  </div>
+                </div> 
               </div>
             </div>
           </div>

--- a/themes/default/templates/page.html
+++ b/themes/default/templates/page.html
@@ -73,7 +73,7 @@
         {{/meta.tags}}
       {{/meta.keywords}}
       {{#meta.category}}
-        <p class="pull-right"><b>Category: </b> {{meta.category}}</p>
+        <p class="pull-right"><b>Category: </b> <a href="{{config.base_url}}/{{meta.category}}">{{meta.category}}</a></p>
       {{/meta.category}}
 
       <div class="page-meta clearfix">

--- a/themes/default/templates/page.html
+++ b/themes/default/templates/page.html
@@ -65,6 +65,16 @@
       {{#meta.title}}<h1 class="title">{{meta.title}}</h1>{{/meta.title}}
 
       {{{content}}}
+      
+      {{#meta.keywords}}
+        <b>Keywords: </b>       
+        {{#meta.tags}}
+          <a href="{{config.base_url}}/?search={{.}}">{{.}}</a> |
+        {{/meta.tags}}
+      {{/meta.keywords}}
+      {{#meta.category}}
+        <p class="pull-right"><b>Category: </b> {{meta.category}}</p>
+      {{/meta.category}}
 
       <div class="page-meta clearfix">
         {{#config.support_email}}


### PR DESCRIPTION
Keywords meta in markdown files is not only searchable, but also it is allowed added through edit pages. It's is also displayed under article as a st of tags with links to each one. I've added also ShowOnHome to edit pages because without it, edit through web page would remove it. Added category, cause I needed to work with category pages that are submitted in separate pull request by @caseyjhol. Category, should be probably taken from folder structure, but I didn't figure it out yet how get it properly.