### PR TITLE
Allow page edit/create/delete in sub-categories

### DIFF
--- a/app/functions/get_filepath.js
+++ b/app/functions/get_filepath.js
@@ -10,19 +10,25 @@ function get_filepath (p) {
   // Default
   var filepath = p.content;
 
-  // Add Category
+  // Add Categories
   if (p.category) {
-    filepath += '/' + sanitize(p.category);
+    if(!Array.isArray(p.category)){
+      p.category = [p.category];
+    }
+    p.category.forEach(function(cat) {
+      filepath = path.join(filepath, sanitize(cat));
+    });
+    
   }
 
   // Add File Name
   if (p.filename) {
-    filepath += '/' + sanitize(p.filename);
+    filepath = path.join(filepath, sanitize(p.filename));
   }
 
   // Normalize
   filepath = path.normalize(filepath);
-
+  
   return filepath;
 
 }

--- a/app/routes/category.create.route.js
+++ b/app/routes/category.create.route.js
@@ -8,9 +8,12 @@ var get_filepath = require('../functions/get_filepath.js');
 function route_category_create (config) {
   return function (req, res, next) {
 
+    // Handle category in file path
+    var req_category = req.body.category.split('/');
+    
     fs.mkdir(get_filepath({
       content  : config.content_dir,
-      category : req.body.category
+      category : req_category
     }), function (error) {
       if (error) {
         return res.json({

--- a/app/routes/page.create.route.js
+++ b/app/routes/page.create.route.js
@@ -7,13 +7,18 @@ var get_filepath = require('../functions/get_filepath.js');
 
 function route_page_create (config) {
   return function (req, res, next) {
-
+    
+    // Handle category in file path
+    var req_file = req.body.name.split('/');
+    var file_name = req_file.pop() + '.md';
+    var req_category = [req.body.category].concat(req_file);
+    
     var filepath = get_filepath({
       content  : config.content_dir,
-      category : req.body.category,
-      filename : req.body.name + '.md'
+      category : req_category,
+      filename : file_name
     });
-
+    
     fs.open(filepath, 'a', function (error, fd) {
       if (error) {
         return res.json({
@@ -21,7 +26,14 @@ function route_page_create (config) {
           message : error
         });
       }
-      fs.close(fd);
+      fs.close(fd, function (error) {
+        if (error) {
+          return res.json({
+            status  : 1,
+            message : error
+          });
+        }
+      });
       res.json({
         status  : 0,
         message : config.lang.api.pageCreated

--- a/app/routes/page.delete.route.js
+++ b/app/routes/page.delete.route.js
@@ -10,14 +10,15 @@ function route_page_delete (config) {
 
     var file_category;
     var file_name;
-
+    
     // Handle category in file path
     var req_file = req.body.file.split('/');
-    if (req_file.length > 2) {
-      file_category = req_file[1];
-      file_name     = req_file[2];
-    } else {
-      file_name     = req_file[1];
+    // Suppress first empty
+    req_file.shift();
+    file_name = req_file.pop();
+    
+    if (req_file.length > 0) {
+      file_category = req_file;
     }
 
     // Generate Filepath

--- a/app/routes/page.edit.route.js
+++ b/app/routes/page.edit.route.js
@@ -11,14 +11,15 @@ function route_page_edit (config) {
 
     var file_category;
     var file_name;
-
+    
     // Handle category in file path
     var req_file = req.body.file.split('/');
-    if (req_file.length > 2) {
-      file_category = req_file[1];
-      file_name     = req_file[2];
-    } else {
-      file_name     = req_file[1];
+    // Suppress first empty
+    req_file.shift();
+    file_name = req_file.pop();
+    
+    if (req_file.length > 0) {
+      file_category = req_file;
     }
 
     // Generate Filepath
@@ -27,7 +28,7 @@ function route_page_edit (config) {
       category : file_category,
       filename : file_name
     });
-
+    
     // No file at that filepath?
     // Add ".md" extension to try again
     if (!fs.existsSync(filepath)) {

--- a/themes/default/templates/layout.html
+++ b/themes/default/templates/layout.html
@@ -87,7 +87,7 @@
   </footer>
 
   {{#config.allow_editing}}
-  {{#loggedIn}}
+  {{#canEdit}}
 
     <!-- Modal: Add Page -->
     <div class="modal fade" id="addModal" tabindex="-1">
@@ -128,7 +128,7 @@
       </div>
     </div>
 
-  {{/loggedIn}}
+  {{/canEdit}}
   {{/config.allow_editing}}
 
   <!-- JavaScript -->


### PR DESCRIPTION
Use '/' to specify a sub-category in modals, i.e. clicking on a '+' next to a category and type 'subcategory/pagename' to create a page inside a sub-category of that category
Backward compatible with get_filepath using category as a string
Use path module to join categories and filepath
Add a callback in fs.close to avoid error