### PR TITLE
Fix issues with login, editing and translations when base_url is set.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -31,7 +31,8 @@ function initialize (config) {
   var oauth2                    = require('./middleware/oauth2.js');
   var route_login               = require('./routes/login.route.js')                    (config);
   var route_login_page          = require('./routes/login_page.route.js')               (config);
-  var route_logout              = require('./routes/logout.route.js');
+  var route_logout              = require('./routes/logout.route.js')
+    (config);
   var route_page_edit           = require('./routes/page.edit.route.js')                (config);
   var route_page_delete         = require('./routes/page.delete.route.js')              (config);
   var route_page_create         = require('./routes/page.create.route.js')              (config);

--- a/app/middleware/always_authenticate.js
+++ b/app/middleware/always_authenticate.js
@@ -5,7 +5,7 @@ function middleware_authenticate (config) {
 
   return function (req, res, next) {
     if (!req.session.loggedIn) {
-      res.redirect(403, '/login');
+      res.redirect(403, config.base_url + '/login');
       return;
     }
     return next();

--- a/app/middleware/authenticate.js
+++ b/app/middleware/authenticate.js
@@ -7,9 +7,9 @@ function middleware_authenticate (config) {
     return function (req, res, next) {
       if (!req.session.loggedIn) {
         if (config.googleoauth === true) {
-          res.redirect(403, '/login');
+          res.redirect(403, config.base_url + '/login');
         } else {
-          res.redirect(403, '/login');
+          res.redirect(403, config.base_url + '/login');
         }
       }
       return next();

--- a/app/middleware/authenticate_read_access.js
+++ b/app/middleware/authenticate_read_access.js
@@ -10,7 +10,7 @@ function middleware_authenticate_read_access (config) {
             req.path === '/login') {
           return next();
         } else {
-          return res.redirect(403, '/login');
+          return res.redirect(403, config.base_url + '/login');
         }
       } else {
         return next();

--- a/app/routes/login_page.route.js
+++ b/app/routes/login_page.route.js
@@ -5,6 +5,7 @@ function route_login_page (config) {
   return function (req, res, next) {
 
     return res.render('login', {
+      config      : config,
       layout      : null,
       lang        : config.lang,
       rtl_layout  : config.rtl_layout,

--- a/app/routes/logout.route.js
+++ b/app/routes/logout.route.js
@@ -1,10 +1,12 @@
 
 'use strict';
 
-function route_logout (req, res, next) {
-  req.session.loggedIn = false;
-  req.session.username = null;
-  res.redirect('/login');
+function route_logout (config) {
+  return function (req, res, next) {
+    req.session.loggedIn = false;
+    req.session.username = null;
+    res.redirect(config.base_url + '/login');
+  }
 }
 
 // Exports

--- a/app/routes/page.create.route.js
+++ b/app/routes/page.create.route.js
@@ -21,7 +21,14 @@ function route_page_create (config) {
           message : error
         });
       }
-      fs.close(fd);
+      fs.close(fd, function (error) {
+        if (error) {
+          return res.json({
+            status  : 1,
+            message : error
+          });
+        }
+      });
       res.json({
         status  : 0,
         message : config.lang.api.pageCreated

--- a/app/routes/page.create.route.js
+++ b/app/routes/page.create.route.js
@@ -28,10 +28,10 @@ function route_page_create (config) {
             message : error
           });
         }
-      });
-      res.json({
-        status  : 0,
-        message : config.lang.api.pageCreated
+        res.json({
+          status  : 0,
+          message : config.lang.api.pageCreated
+        });
       });
     });
 

--- a/themes/default/public/scripts/login.js
+++ b/themes/default/public/scripts/login.js
@@ -3,6 +3,8 @@ jQuery(document).ready(function () {
 
   'use strict';
 
+  var base_url = (typeof rn_base_url === "undefined") ? "" : rn_base_url;
+
   // Form validation
   $('.login-form input[type="text"], .login-form input[type="password"], .login-form textarea')
     .on('focus', function () {
@@ -23,7 +25,7 @@ jQuery(document).ready(function () {
       });
 
       if ($('.input-error').length === 0) {
-        $.post(rn_base_url() + '/rn-login', $(this).serialize(), function (data) {
+        $.post(base_url + '/rn-login', $(this).serialize(), function (data) {
 
           swal({
             type              : data.status ? 'success' : 'warning',
@@ -34,7 +36,7 @@ jQuery(document).ready(function () {
 
           if (data.status) {
             window.setTimeout(function () {
-              window.location = rn_base_url() + '/';
+              window.location = base_url + '/';
             }, 1500);
           }
 

--- a/themes/default/public/scripts/login.js
+++ b/themes/default/public/scripts/login.js
@@ -23,7 +23,7 @@ jQuery(document).ready(function () {
       });
 
       if ($('.input-error').length === 0) {
-        $.post('/rn-login', $(this).serialize(), function (data) {
+        $.post(rn_base_url() + '/rn-login', $(this).serialize(), function (data) {
 
           swal({
             type              : data.status ? 'success' : 'warning',
@@ -34,7 +34,7 @@ jQuery(document).ready(function () {
 
           if (data.status) {
             window.setTimeout(function () {
-              window.location = '/';
+              window.location = rn_base_url() + '/';
             }, 1500);
           }
 

--- a/themes/default/public/scripts/raneto.js
+++ b/themes/default/public/scripts/raneto.js
@@ -62,9 +62,12 @@
 
     // Modal: Delete Page Confirm
     $("#delete-page-confirm").click(function () {
+      var file_arr = window.location.pathname.split("/");
+      var base_arr = rn_base_url().split("/");
+      file_arr.splice(0, base_arr.length, "");
       $("#deleteModal").modal("hide");
       $.post(rn_base_url() + "/rn-delete", {
-        file : decodeURI(window.location.pathname)
+        file : decodeURI(file_arr.join("/"))
       }, function (data) {
         switch (data.status) {
           case 0:

--- a/themes/default/public/scripts/raneto.js
+++ b/themes/default/public/scripts/raneto.js
@@ -3,6 +3,8 @@
 
   "use strict";
 
+  var base_url = (typeof rn_base_url === "undefined") ? "" : rn_base_url;
+
   var current_category;
 
   $(document).ready(function () {
@@ -39,7 +41,7 @@
     $("#add-page-confirm").click(function () {
       $("#addModal").modal("hide");
       var name = $("#page-name").val().replace(/\s+/g, "-");
-      $.post(rn_base_url() + "/rn-add-page", {
+      $.post(base_url + "/rn-add-page", {
         name     : name,
         category : current_category
       }, function (data) {
@@ -52,30 +54,30 @@
             }
             redirect.push(name);
             redirect.push("edit");
-            window.location = rn_base_url() + redirect.join("/");
+            window.location = base_url + redirect.join("/");
             break;
         }
       }).fail(function(data) {
-        if (data.status === 403) { window.location = rn_base_url() + "/login"; }
+        if (data.status === 403) { window.location = base_url + "/login"; }
       });
     });
 
     // Modal: Delete Page Confirm
     $("#delete-page-confirm").click(function () {
       var file_arr = window.location.pathname.split("/");
-      var base_arr = rn_base_url().split("/");
+      var base_arr = base_url.split("/");
       file_arr.splice(0, base_arr.length, "");
       $("#deleteModal").modal("hide");
-      $.post(rn_base_url() + "/rn-delete", {
+      $.post(base_url + "/rn-delete", {
         file : decodeURI(file_arr.join("/"))
       }, function (data) {
         switch (data.status) {
           case 0:
-            window.location = rn_base_url() + "/";
+            window.location = base_url + "/";
             break;
         }
       }).fail(function(data) {
-        if (data.status === 403) { window.location = rn_base_url() + "/login"; }
+        if (data.status === 403) { window.location = base_url + "/login"; }
       });
     });
 
@@ -96,7 +98,7 @@
     // New Category
     $("#newCategory").keypress(function (e) {
       if (e.which === 13) {
-        $.post(rn_base_url() + "/rn-add-category", {
+        $.post(base_url + "/rn-add-category", {
           category : $(this).val()
                             .trim()
                             .toLowerCase()
@@ -104,7 +106,7 @@
         }, function (data) {
           location.reload();
         }).fail(function(data) {
-        if (data.status === 403) { window.location = rn_base_url() + "/login"; }
+        if (data.status === 403) { window.location = base_url + "/login"; }
       });
       }
     });
@@ -118,16 +120,16 @@
     });
 
     // get translations first, then register save handlers
-    $.getJSON(rn_base_url() + "/translations/" + $("html").prop("lang") + ".json", null, function (lang) {
+    $.getJSON(base_url + "/translations/" + $("html").prop("lang") + ".json", null, function (lang) {
 
       // Save Page
       $(".save-page").click(function () {
         var file_arr = window.location.pathname.split("/");
-        var base_arr = rn_base_url().split("/");
+        var base_arr = base_url.split("/");
         file_arr.splice(0, base_arr.length, "");
         file_arr.pop();
         $("#entry-markdown").next(".CodeMirror")[0].CodeMirror.save();
-        $.post(rn_base_url() + "/rn-edit", {
+        $.post(base_url + "/rn-edit", {
           file    : decodeURI(file_arr.join("/")),
           content : $("#entry-markdown").val(),
           meta_title : $("#entry-metainfo-title").val(),
@@ -153,7 +155,7 @@
               break;
           }
         }).fail(function(data) {
-          if (data.status === 403) { window.location = rn_base_url() + "/login"; }
+          if (data.status === 403) { window.location = base_url + "/login"; }
         });
       });
 

--- a/themes/default/public/scripts/raneto.js
+++ b/themes/default/public/scripts/raneto.js
@@ -39,7 +39,7 @@
     $("#add-page-confirm").click(function () {
       $("#addModal").modal("hide");
       var name = $("#page-name").val().replace(/\s+/g, "-");
-      $.post("/rn-add-page", {
+      $.post(rn_base_url() + "/rn-add-page", {
         name     : name,
         category : current_category
       }, function (data) {
@@ -52,27 +52,27 @@
             }
             redirect.push(name);
             redirect.push("edit");
-            window.location = redirect.join("/");
+            window.location = redirect.join(rn_base_url() + "/");
             break;
         }
       }).fail(function(data) {
-        if (data.status === 403) { window.location = "/login"; }
+        if (data.status === 403) { window.location = rn_base_url() + "/login"; }
       });
     });
 
     // Modal: Delete Page Confirm
     $("#delete-page-confirm").click(function () {
       $("#deleteModal").modal("hide");
-      $.post("/rn-delete", {
+      $.post(rn_base_url() + "/rn-delete", {
         file : decodeURI(window.location.pathname)
       }, function (data) {
         switch (data.status) {
           case 0:
-            window.location = "/";
+            window.location = rn_base_url() + "/";
             break;
         }
       }).fail(function(data) {
-        if (data.status === 403) { window.location = "/login"; }
+        if (data.status === 403) { window.location = rn_base_url() + "/login"; }
       });
     });
 
@@ -93,7 +93,7 @@
     // New Category
     $("#newCategory").keypress(function (e) {
       if (e.which === 13) {
-        $.post("/rn-add-category", {
+        $.post(rn_base_url() + "/rn-add-category", {
           category : $(this).val()
                             .trim()
                             .toLowerCase()
@@ -101,7 +101,7 @@
         }, function (data) {
           location.reload();
         }).fail(function(data) {
-        if (data.status === 403) { window.location = "/login"; }
+        if (data.status === 403) { window.location = rn_base_url() + "/login"; }
       });
       }
     });
@@ -115,14 +115,16 @@
     });
 
     // get translations first, then register save handlers
-    $.getJSON("/translations/" + $("html").prop("lang") + ".json", null, function (lang) {
+    $.getJSON(rn_base_url() + "/translations/" + $("html").prop("lang") + ".json", null, function (lang) {
 
       // Save Page
       $(".save-page").click(function () {
         var file_arr = window.location.pathname.split("/");
+        var base_arr = rn_base_url().split("/");
+        file_arr.splice(0, base_arr.length, "");
         file_arr.pop();
         $("#entry-markdown").next(".CodeMirror")[0].CodeMirror.save();
-        $.post("/rn-edit", {
+        $.post(rn_base_url() + "/rn-edit", {
           file    : decodeURI(file_arr.join("/")),
           content : $("#entry-markdown").val(),
           meta_title : $("#entry-metainfo-title").val(),
@@ -148,7 +150,7 @@
               break;
           }
         }).fail(function(data) {
-          if (data.status === 403) { window.location = "/login"; }
+          if (data.status === 403) { window.location = rn_base_url() + "/login"; }
         });
       });
 

--- a/themes/default/public/scripts/raneto.js
+++ b/themes/default/public/scripts/raneto.js
@@ -52,7 +52,7 @@
             }
             redirect.push(name);
             redirect.push("edit");
-            window.location = redirect.join(rn_base_url() + "/");
+            window.location = rn_base_url() + redirect.join("/");
             break;
         }
       }).fail(function(data) {

--- a/themes/default/templates/layout.html
+++ b/themes/default/templates/layout.html
@@ -11,7 +11,7 @@
   <link rel="shortcut icon" href="{{config.base_url}}/favicon.ico">
   <link rel="stylesheet" href="{{config.base_url}}/lib/bootstrap/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{config.base_url}}/lib/highlightjs/styles/solarized_light.css">
-  <script>function rn_base_url() { return "{{config.base_url}}"; }</script>
+  <script>var rn_base_url = "{{config.base_url}}";</script>
   <link rel="stylesheet" href="{{config.base_url}}/styles/raneto.css">
   <link rel="stylesheet" href="{{config.base_url}}/styles/ghostdown.css">
   {{#config.rtl_layout}}

--- a/themes/default/templates/layout.html
+++ b/themes/default/templates/layout.html
@@ -11,6 +11,7 @@
   <link rel="shortcut icon" href="{{config.base_url}}/favicon.ico">
   <link rel="stylesheet" href="{{config.base_url}}/lib/bootstrap/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{config.base_url}}/lib/highlightjs/styles/solarized_light.css">
+  <script>function rn_base_url() { return "{{config.base_url}}"; }</script>
   <link rel="stylesheet" href="{{config.base_url}}/styles/raneto.css">
   <link rel="stylesheet" href="{{config.base_url}}/styles/ghostdown.css">
   {{#config.rtl_layout}}

--- a/themes/default/templates/login.html
+++ b/themes/default/templates/login.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="{{config.base_url}}/favicon.ico">
     <link rel="stylesheet" href="{{config.base_url}}/lib/bootstrap/dist/css/bootstrap.min.css">
+    <script>function rn_base_url() { return "{{config.base_url}}"; }</script>
     <link rel="stylesheet" href="{{config.base_url}}/styles/raneto.css">
     <link rel="stylesheet" href="{{config.base_url}}/styles/login-form.css">
     <link rel="stylesheet" href="{{config.base_url}}/styles/login-style.css">

--- a/themes/default/templates/login.html
+++ b/themes/default/templates/login.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="{{config.base_url}}/favicon.ico">
     <link rel="stylesheet" href="{{config.base_url}}/lib/bootstrap/dist/css/bootstrap.min.css">
-    <script>function rn_base_url() { return "{{config.base_url}}"; }</script>
+    <script>var rn_base_url = "{{config.base_url}}";</script>
     <link rel="stylesheet" href="{{config.base_url}}/styles/raneto.css">
     <link rel="stylesheet" href="{{config.base_url}}/styles/login-form.css">
     <link rel="stylesheet" href="{{config.base_url}}/styles/login-style.css">


### PR DESCRIPTION
This address problems raised in #200, #279 and also most likely #189.

Specifically, when ``base_url`` was being set, any URLs generated from the Javascript running in the browser was not including the ``base_url`` value.

For the login page, the ``config`` object was also not being passed in when rendering. This was needed as the template file was trying to access it to use ``base_url`` in links in the HTML generated from the server.

The changes should result in the following now working correctly when ``base_url`` is used.

* Login.
* Page editing.
* Translations.

Note that this only fixes the authentication using forms based login. I haven't tried to address login using Google OAuth, as I am not setup to test that at the moment. Suggest that any changes related to making Google OAuth work when ``base_url`` is used be addressed after this change is tested and merged.