### PR TITLE
Async IO

### DIFF
--- a/app/core/contents.js
+++ b/app/core/contents.js
@@ -75,7 +75,7 @@ async function processFile (config, activePageSlug, contentDir, filePath) {
 
     let dirMetadata = {};
     try {
-      const metaFile = await fs.readFile(contentDir + shortPath + '/meta');
+      const metaFile = await fs.readFile(path.join(contentDir, shortPath, 'meta'));
       dirMetadata = contentProcessors.cleanObjectStrings(yaml.safeLoad(metaFile.toString('utf-8')));
     } catch (e) {
       if (config.debug) {
@@ -85,7 +85,7 @@ async function processFile (config, activePageSlug, contentDir, filePath) {
 
     if (category_sort && !dirMetadata.sort) {
       try {
-        const sortFile = await fs.readFile(contentDir + shortPath + '/sort');
+        const sortFile = await fs.readFile(path.join(contentDir, shortPath, 'sort'));
         sort = parseInt(sortFile.toString('utf-8'), 10);
       } catch (e) {
         if (config.debug) {
@@ -95,13 +95,13 @@ async function processFile (config, activePageSlug, contentDir, filePath) {
     }
 
     return {
-      slug: shortPath,
+      slug: fileSlug,
       title: dirMetadata.title || _s.titleize(_s.humanize(path.basename(shortPath))),
       show_on_home: dirMetadata.show_on_home ? (dirMetadata.show_on_home === 'true') : config.show_on_home_default,
       is_index: false,
       is_directory: true,
       active: activePageSlug.startsWith('/' + fileSlug),
-      class: 'category-' + contentProcessors.cleanString(shortPath),
+      class: 'category-' + contentProcessors.cleanString(fileSlug),
       sort: dirMetadata.sort || sort,
       files: []
     };

--- a/app/core/contents.js
+++ b/app/core/contents.js
@@ -56,11 +56,7 @@ async function processFile (config, activePageSlug, contentDir, filePath) {
   const category_sort = config.category_sort || false;
   const shortPath = path.normalize(filePath).replace(content_dir, '').trim();
   const fileSlug = shortPath.split('\\').join('/');
-  let stat = await fs.lstat(filePath);
-
-  if (stat.isSymbolicLink()) {
-    stat = await fs.lstat(await fs.readlink(filePath));
-  }
+  const stat = await fs.stat(filePath);
 
   if (stat.isDirectory()) {
 

--- a/app/core/contents.js
+++ b/app/core/contents.js
@@ -2,23 +2,19 @@
 'use strict';
 
 const path              = require('path');
-const fs                = require('fs');
-const glob              = require('glob');
+const fs                = require('fs-extra');
 const _                 = require('underscore');
 const _s                = require('underscore.string');
 const yaml              = require('js-yaml');
 const utils             = require('./utils');
 const contentProcessors = require('../functions/contentProcessors');
 
-function handler (activePageSlug, config) {
+async function handler (activePageSlug, config) {
   activePageSlug = activePageSlug || '';
   const baseSlug = activePageSlug.split(/[\\/]/).slice(0, -1).join('/');
-  const page_sort_meta = config.page_sort_meta || '';
-  const category_sort = config.category_sort || false;
   const contentDir = utils.normalizeDir(path.normalize(config.content_dir));
 
-  const files = glob.sync(contentDir + '**/*');
-  const content_dir = path.normalize(contentDir);
+  const files = await utils.promiseGlob(contentDir + '**/*');
   const filesProcessed = [];
 
   filesProcessed.push({
@@ -32,98 +28,19 @@ function handler (activePageSlug, config) {
     files: []
   });
 
-  files.forEach(filePath => {
+  const results = await Promise.all(
+    files.map(filePath => processFile(config, activePageSlug, contentDir, filePath))
+  );
 
-    const shortPath = path.normalize(filePath).replace(content_dir, '').trim();
-    const fileSlug = shortPath.split('\\').join('/');
-    let stat = fs.lstatSync(filePath);
-
-    if (stat.isSymbolicLink()) {
-      stat = fs.lstatSync(fs.readlinkSync(filePath));
+  for (const result of results) {
+    if (result && result.is_directory) {
+      filesProcessed.push(result);
+    } else if (result && !result.is_directory) {
+      const dirSlug = path.dirname(result.slug);
+      const parent = _.find(filesProcessed, item => item.slug === dirSlug);
+      parent.files.push(result);
     }
-
-    if (stat.isDirectory()) {
-
-      let sort = 0;
-      // ignore directories that has an ignore file under it
-      const ignoreFile = contentDir + shortPath + '/ignore';
-
-      if (fs.existsSync(ignoreFile) && fs.lstatSync(ignoreFile).isFile()) {
-        return true;
-      }
-
-      let dirMetadata = {};
-      try {
-        const metaFile = fs.readFileSync(contentDir + shortPath + '/meta');
-        dirMetadata = contentProcessors.cleanObjectStrings(yaml.safeLoad(metaFile.toString('utf-8')));
-      } catch (e) {
-        if (config.debug) {
-          console.log('No meta file for', contentDir + shortPath);
-        }
-      }
-
-      if (category_sort && !dirMetadata.sort) {
-        try {
-          const sortFile = fs.readFileSync(contentDir + shortPath + '/sort');
-          sort = parseInt(sortFile.toString('utf-8'), 10);
-        } catch (e) {
-          if (config.debug) {
-            console.log('No sort file for', contentDir + shortPath);
-          }
-        }
-      }
-
-      filesProcessed.push({
-        slug: shortPath,
-        title: dirMetadata.title || _s.titleize(_s.humanize(path.basename(shortPath))),
-        show_on_home: dirMetadata.show_on_home ? (dirMetadata.show_on_home === 'true') : config.show_on_home_default,
-        is_index: false,
-        is_directory: true,
-        active: activePageSlug.startsWith('/' + fileSlug),
-        class: 'category-' + contentProcessors.cleanString(shortPath),
-        sort: dirMetadata.sort || sort,
-        files: []
-      });
-
-    }
-
-    if (stat.isFile() && path.extname(shortPath) === '.md') {
-      try {
-
-        const file = fs.readFileSync(filePath);
-        let slug = fileSlug;
-        let pageSort = 0;
-
-        if (fileSlug.indexOf('index.md') > -1) {
-          slug = slug.replace('index.md', '');
-        }
-
-        slug = slug.replace('.md', '').trim();
-
-        const dir = path.dirname(shortPath);
-        const meta = contentProcessors.processMeta(file.toString('utf-8'));
-
-        if (page_sort_meta && meta[page_sort_meta]) {
-          pageSort = parseInt(meta[page_sort_meta], 10);
-        }
-
-        const val = _.find(filesProcessed, item => item.slug === dir);
-        val.files.push({
-          slug: slug,
-          title: meta.title ? meta.title : contentProcessors.slugToTitle(slug),
-          show_on_home: meta.show_on_home ? (meta.show_on_home === 'true') : config.show_on_home_default,
-          is_directory: false,
-          active: (activePageSlug.trim() === '/' + slug),
-          sort: pageSort
-        });
-
-      } catch (e) {
-        if (config.debug) {
-          console.log(e);
-        }
-      }
-    }
-  });
+  }
 
   const sortedFiles = _.sortBy(filesProcessed, cat => cat.sort);
   sortedFiles.forEach(category => {
@@ -131,6 +48,99 @@ function handler (activePageSlug, config) {
   });
 
   return sortedFiles;
+}
+
+async function processFile (config, activePageSlug, contentDir, filePath) {
+  const content_dir = path.normalize(contentDir);
+  const page_sort_meta = config.page_sort_meta || '';
+  const category_sort = config.category_sort || false;
+  const shortPath = path.normalize(filePath).replace(content_dir, '').trim();
+  const fileSlug = shortPath.split('\\').join('/');
+  let stat = await fs.lstat(filePath);
+
+  if (stat.isSymbolicLink()) {
+    stat = await fs.lstat(await fs.readlink(filePath));
+  }
+
+  if (stat.isDirectory()) {
+
+    let sort = 0;
+    // ignore directories that has an ignore file under it
+    const ignoreFile = contentDir + shortPath + '/ignore';
+
+    const ignoreExists = await fs.lstat(ignoreFile).then(stat => stat.isFile(), () => {});
+    if (ignoreExists) {
+      return true;
+    }
+
+    let dirMetadata = {};
+    try {
+      const metaFile = await fs.readFile(contentDir + shortPath + '/meta');
+      dirMetadata = contentProcessors.cleanObjectStrings(yaml.safeLoad(metaFile.toString('utf-8')));
+    } catch (e) {
+      if (config.debug) {
+        console.log('No meta file for', contentDir + shortPath);
+      }
+    }
+
+    if (category_sort && !dirMetadata.sort) {
+      try {
+        const sortFile = await fs.readFile(contentDir + shortPath + '/sort');
+        sort = parseInt(sortFile.toString('utf-8'), 10);
+      } catch (e) {
+        if (config.debug) {
+          console.log('No sort file for', contentDir + shortPath);
+        }
+      }
+    }
+
+    return {
+      slug: shortPath,
+      title: dirMetadata.title || _s.titleize(_s.humanize(path.basename(shortPath))),
+      show_on_home: dirMetadata.show_on_home ? (dirMetadata.show_on_home === 'true') : config.show_on_home_default,
+      is_index: false,
+      is_directory: true,
+      active: activePageSlug.startsWith('/' + fileSlug),
+      class: 'category-' + contentProcessors.cleanString(shortPath),
+      sort: dirMetadata.sort || sort,
+      files: []
+    };
+
+  }
+
+  if (stat.isFile() && path.extname(shortPath) === '.md') {
+    try {
+      const file = await fs.readFile(filePath);
+      let slug = fileSlug;
+      let pageSort = 0;
+
+      if (fileSlug.indexOf('index.md') > -1) {
+        slug = slug.replace('index.md', '');
+      }
+
+      slug = slug.replace('.md', '').trim();
+
+      const meta = contentProcessors.processMeta(file.toString('utf-8'));
+
+      if (page_sort_meta && meta[page_sort_meta]) {
+        pageSort = parseInt(meta[page_sort_meta], 10);
+      }
+
+      return {
+        slug: slug,
+        title: meta.title ? meta.title : contentProcessors.slugToTitle(slug),
+        show_on_home: meta.show_on_home ? (meta.show_on_home === 'true') : config.show_on_home_default,
+        is_directory: false,
+        active: (activePageSlug.trim() === '/' + slug),
+        sort: pageSort
+      };
+
+    } catch (e) {
+      if (config.debug) {
+        console.log(e);
+      }
+    }
+  }
 }
 
 exports.default = handler;

--- a/app/core/page.js
+++ b/app/core/page.js
@@ -2,17 +2,17 @@
 'use strict';
 
 const path              = require('path');
-const fs                = require('fs');
+const fs                = require('fs-extra');
 const utils             = require('./utils');
 const _s                = require('underscore.string');
 const marked            = require('marked');
 const contentProcessors = require('../functions/contentProcessors');
 
-function handler (filePath, config) {
+async function handler (filePath, config) {
   const contentDir = utils.normalizeDir(path.normalize(config.content_dir));
 
   try {
-    const file = fs.readFileSync(filePath);
+    const file = await fs.readFile(filePath);
     let slug = utils.getSlug(filePath, contentDir);
 
     if (slug.indexOf('index.md') > -1) {

--- a/app/core/search.js
+++ b/app/core/search.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const path              = require('path');
-const glob              = require('glob');
 const contentProcessors = require('../functions/contentProcessors');
 const utils             = require('./utils');
 const pageHandler       = require('./page');
@@ -30,13 +29,15 @@ function getStemmers (config) {
   return stemmers;
 }
 
-function handler (query, config) {
+async function handler (query, config) {
   const contentDir = utils.normalizeDir(path.normalize(config.content_dir));
-  const documents = glob
-    .sync(contentDir + '**/*.md')
-    .map(filePath => contentProcessors.extractDocument(
+  const rawDocuments = await utils.promiseGlob(contentDir + '**/*.md');
+  const potentialDocuments = await Promise.all(
+    rawDocuments.map(filePath => contentProcessors.extractDocument(
       contentDir, filePath, config.debug
     ))
+  );
+  const documents = potentialDocuments
     .filter(doc => doc !== null);
 
   const lunrInstance = getLunr(config);
@@ -48,16 +49,20 @@ function handler (query, config) {
     documents.forEach((doc) => this.add(doc), this);
   });
 
-  const results       = idx.search(query);
-  const searchResults = [];
+  const results = idx.search(query);
 
-  results.forEach(result => {
-    const p = pageHandler(contentDir + result.ref, config);
-    p.excerpt = p.excerpt.replace(new RegExp('(' + query + ')', 'gim'), '<span class="search-query">$1</span>');
-    searchResults.push(p);
-  });
+  const searchResults = await Promise.all(
+    results.map(result => processSearchResult(contentDir, config, query, result))
+  );
 
   return searchResults;
+}
+
+async function processSearchResult (contentDir, config, query, result) {
+  const page = await pageHandler(contentDir + result.ref, config);
+  page.excerpt = page.excerpt.replace(new RegExp('(' + query + ')', 'gim'), '<span class="search-query">$1</span>');
+
+  return page;
 }
 
 exports.default = handler;

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1,24 +1,30 @@
 
 'use strict';
 
-const fs     = require('fs');
+const glob   = require('glob');
+const fs     = require('fs-extra');
+const util   = require('util');
 const moment = require('moment');
+
+const promiseGlob = util.promisify(glob);
 
 const normalizeDir = (dir) => dir.replace(/\\/g, '/');
 const getSlug      = (filePath, contentDir) => normalizeDir(filePath).replace(normalizeDir(contentDir), '').trim();
 
-function getLastModified (config, meta, file_path) {
+async function getLastModified (config, meta, file_path) {
   if (typeof meta.modified !== 'undefined') {
     return moment(meta.modified).format(config.datetime_format);
   } else {
-    return moment(fs.lstatSync(file_path).mtime).format(config.datetime_format);
+    const { mtime } = await fs.lstat(file_path);
+    return moment(mtime).format(config.datetime_format);
   }
 }
 
 exports.default = {
   normalizeDir,
   getLastModified,
-  getSlug
+  getSlug,
+  promiseGlob
 };
 
 module.exports = exports.default;

--- a/app/functions/build_nested_pages.js
+++ b/app/functions/build_nested_pages.js
@@ -1,14 +1,12 @@
 
 'use strict';
 
-var path = require('path');
-
 function build_nested_pages (pages) {
   var result = [];
   var i = pages.length;
 
   while (i--) {
-    if (pages[i].slug.split(path.sep).length > 1) {
+    if (pages[i].slug.split('/').length > 1) {
       var parent = find_by_slug(pages, pages[i]);
       parent.files.unshift(pages[i]);
     } else {
@@ -21,7 +19,7 @@ function build_nested_pages (pages) {
 
 function find_by_slug (pages, page) {
   return pages.find(function (element) {
-    return element.slug === page.slug.split(path.sep).slice(0, -1).join(path.sep);
+    return element.slug === page.slug.split('/').slice(0, -1).join('/');
   });
 }
 

--- a/app/functions/contentProcessors.js
+++ b/app/functions/contentProcessors.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const path = require('path');
-const fs   = require('fs');
+const fs   = require('fs-extra');
 const _s   = require('underscore.string');
 const yaml = require('js-yaml');
 
@@ -112,9 +112,9 @@ function processVars (markdownContent, config) {
   return markdownContent;
 }
 
-function extractDocument (contentDir, filePath, debug) {
+async function extractDocument (contentDir, filePath, debug) {
   try {
-    const file = fs.readFileSync(filePath);
+    const file = await fs.readFile(filePath);
     const meta = processMeta(file.toString('utf-8'));
 
     const id    = filePath.replace(contentDir, '').trim();

--- a/app/index.js
+++ b/app/index.js
@@ -73,7 +73,7 @@ function initialize (config) {
     router.use(express.static(path.join(config.theme_dir, config.theme_name, 'public')));
   }
   router.use(config.image_url, express.static(path.normalize(config.content_dir + config.image_url)));
-  router.use('/translations',  express.static(path.normalize(__dirname + '/translations')));
+  router.use('/translations',  express.static(path.normalize(path.join(__dirname, 'translations'))));
 
   // HTTP Authentication
   if (config.authentication === true || config.authentication_for_edit || config.authentication_for_read) {

--- a/app/index.js
+++ b/app/index.js
@@ -31,8 +31,7 @@ function initialize (config) {
   var oauth2                    = require('./middleware/oauth2.js');
   var route_login               = require('./routes/login.route.js')                    (config);
   var route_login_page          = require('./routes/login_page.route.js')               (config);
-  var route_logout              = require('./routes/logout.route.js')
-    (config);
+  var route_logout              = require('./routes/logout.route.js')                   (config);
   var route_page_edit           = require('./routes/page.edit.route.js')                (config);
   var route_page_delete         = require('./routes/page.delete.route.js')              (config);
   var route_page_create         = require('./routes/page.create.route.js')              (config);

--- a/app/routes/home.route.js
+++ b/app/routes/home.route.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // Modules
-var fs                             = require('fs');
+var fs                             = require('fs-extra');
 var _                              = require('underscore');
 var build_nested_pages             = require('../functions/build_nested_pages.js');
 var get_filepath                   = require('../functions/get_filepath.js');
@@ -12,7 +12,7 @@ const contentsHandler = require('../core/contents');
 const utils = require('../core/utils');
 
 function route_home (config) {
-  return function (req, res, next) {
+  return async function (req, res, next) {
 
     // Generate Filepath
     var filepath = get_filepath({
@@ -22,7 +22,7 @@ function route_home (config) {
 
     // Do we have an index.md file?
     // If so, use that.
-    if (fs.existsSync(filepath + '.md')) {
+    if (await fs.pathExists(filepath + '.md')) {
       return next();
     }
 
@@ -39,7 +39,7 @@ function route_home (config) {
 
     // Filter out the image content directory and items with show_on_home == false
     var pageList = remove_image_content_directory(config,
-      _.chain(contentsHandler('/index', config))
+      _.chain(await contentsHandler('/index', config))
         .filter(function (page) { return page.show_on_home; })
         .map(function (page) {
           page.files = _.filter(page.files, function (file) { return file.show_on_home; });
@@ -52,7 +52,7 @@ function route_home (config) {
       pages         : build_nested_pages(pageList),
       body_class    : 'page-home',
       meta          : config.home_meta,
-      last_modified : utils.getLastModified(config, config.home_meta, template_filepath),
+      last_modified : await utils.getLastModified(config, config.home_meta, template_filepath),
       lang          : config.lang,
       loggedIn      : ((config.authentication || config.authentication_for_edit) ? req.session.loggedIn : false),
       username      : ((config.authentication || config.authentication_for_edit) ? req.session.username : null)

--- a/app/routes/page.delete.route.js
+++ b/app/routes/page.delete.route.js
@@ -2,11 +2,11 @@
 'use strict';
 
 // Modules
-var fs           = require('fs');
+var fs           = require('fs-extra');
 var get_filepath = require('../functions/get_filepath.js');
 
 function route_page_delete (config) {
-  return function (req, res, next) {
+  return async function (req, res, next) {
 
     var file_category;
     var file_name;
@@ -29,25 +29,25 @@ function route_page_delete (config) {
 
     // No file at that filepath?
     // Add ".md" extension to try again
-    if (!fs.existsSync(filepath)) {
+    if (!(await fs.pathExists(filepath))) {
       filepath += '.md';
     }
 
-    // Don't Delete
-    // Rename to remove from listing
-    fs.rename(filepath, filepath + '.del', function (error) {
-      if (error) {
-        return res.json({
-          status  : 1,
-          message : error
-        });
-      }
+    try {
+      // Don't Delete
+      // Rename to remove from listing
+      await fs.rename(filepath, filepath + '.del');
+
       res.json({
         status  : 0,
         message : config.lang.api.pageDeleted
       });
-    });
-
+    } catch (error) {
+      res.json({
+        status  : 1,
+        message : error
+      });
+    }
   };
 }
 

--- a/app/routes/page.edit.route.js
+++ b/app/routes/page.edit.route.js
@@ -2,12 +2,12 @@
 'use strict';
 
 // Modules
-var fs               = require('fs');
+var fs               = require('fs-extra');
 var get_filepath     = require('../functions/get_filepath.js');
 var create_meta_info = require('../functions/create_meta_info.js');
 
 function route_page_edit (config) {
-  return function (req, res, next) {
+  return async function (req, res, next) {
 
     var file_category;
     var file_name;
@@ -30,7 +30,7 @@ function route_page_edit (config) {
 
     // No file at that filepath?
     // Add ".md" extension to try again
-    if (!fs.existsSync(filepath)) {
+    if (!(await fs.pathExists(filepath))) {
       filepath += '.md';
     }
 
@@ -42,19 +42,19 @@ function route_page_edit (config) {
 
     var complete_content = create_content(req.body);
 
-    fs.writeFile(filepath, complete_content, function (error) {
-      if (error) {
-        return res.json({
-          status  : 1,
-          message : error
-        });
-      }
+    try {
+      await fs.writeFile(filepath, complete_content);
+
       res.json({
         status  : 0,
         message : config.lang.api.pageSaved
       });
-    });
-
+    } catch (error) {
+      res.json({
+        status  : 1,
+        message : error
+      });
+    }
   };
 }
 

--- a/app/routes/search.route.js
+++ b/app/routes/search.route.js
@@ -10,7 +10,7 @@ const searchHandler = require('../core/search');
 const contentsHandler = require('../core/contents');
 
 function route_search (config) {
-  return function (req, res, next) {
+  return async function (req, res, next) {
 
     // Skip if Search not present
     if (!req.query.search) { return next(); }
@@ -25,8 +25,8 @@ function route_search (config) {
     // trim and convert to string
     var searchQuery    = validator.toString(sanitizedQuery).trim();
 
-    var searchResults  = searchHandler(searchQuery, config);
-    var pageListSearch = remove_image_content_directory(config, contentsHandler(null, config));
+    var searchResults  = await searchHandler(searchQuery, config);
+    var pageListSearch = remove_image_content_directory(config, await contentsHandler(null, config));
 
     // TODO: Move to Raneto Core
     // Loop through Results and Extract Category

--- a/app/routes/sitemap.route.js
+++ b/app/routes/sitemap.route.js
@@ -3,65 +3,77 @@
 
 // Modules
 var path                = require('path');
-var fs                  = require('fs');
+var fs                  = require('fs-extra');
 var sm                  = require('sitemap');
 var _                   = require('underscore');
 const contentProcessors = require('../functions/contentProcessors');
 const utils             = require('../core/utils');
 
 function route_sitemap (config) {
-  return function (req, res, next) {
+  return async function (req, res, next) {
 
     var hostname = config.hostname || req.headers.host;
     var content_dir = path.normalize(config.content_dir);
 
     // get list md files
-    var files = listFiles(content_dir);
-    files = _.filter(files, function (file) {
-      return file.substr(-3) === '.md';
-    });
+    try {
+      var files = await listFiles(content_dir);
 
-    var filesPath = files.map(function (file) {
-      return file.replace(content_dir, '');
-    });
-
-    // generate list urls
-    var urls = filesPath.map(function (file) {
-      return '/' + file.replace('.md', '').replace('\\', '/');
-    });
-
-    // create sitemap.xml
-    var sitemap = sm.createSitemap({
-      hostname: 'http://' + hostname,
-      cacheTime: 600000
-    });
-
-    for (var i = 0, len = urls.length; i < len; i++) {
-      var content = fs.readFileSync(files[i], 'utf8');
-      // Need to override the datetime format for sitemap
-      var conf = {
-        datetime_format : 'YYYY-MM-DD'
-      };
-      sitemap.add({
-        url: (config.prefix_url || '') + urls[i],
-        changefreq: 'weekly',
-        priority: 0.8,
-        lastmod: utils.getLastModified(conf, contentProcessors.processMeta(content), files[i])
+      files = _.filter(files, function (file) {
+        return file.substr(-3) === '.md';
       });
+
+      var filesPath = files.map(function (file) {
+        return file.replace(content_dir, '');
+      });
+
+      // generate list urls
+      var urls = filesPath.map(function (file) {
+        return '/' + file.replace('.md', '').replace('\\', '/');
+      });
+
+      // create sitemap.xml
+      var sitemap = sm.createSitemap({
+        hostname: 'http://' + hostname,
+        cacheTime: 600000
+      });
+
+      for (var i = 0, len = urls.length; i < len; i++) {
+        var content = await fs.readFile(files[i], 'utf8');
+        // Need to override the datetime format for sitemap
+        var conf = {
+          datetime_format : 'YYYY-MM-DD'
+        };
+        sitemap.add({
+          url: (config.prefix_url || '') + urls[i],
+          changefreq: 'weekly',
+          priority: 0.8,
+          lastmod: await utils.getLastModified(conf, contentProcessors.processMeta(content), files[i])
+        });
+      }
+
+      res.header('Content-Type', 'application/xml');
+      res.send(sitemap.toString());
+    } catch (error) {
+      next(error);
     }
-
-    res.header('Content-Type', 'application/xml');
-    res.send(sitemap.toString());
-
   };
 }
 
-function listFiles (dir) {
-  return fs.readdirSync(dir).reduce(function (list, file) {
-    var name = path.join(dir, file);
-    var isDir = fs.statSync(name).isDirectory();
-    return list.concat(isDir ? listFiles(name) : [name]);
-  }, []);
+async function listFiles (dir) {
+  const entries = await fs.readdir(dir);
+
+  // Build an array of arrays with all sub-files
+  const paths = await Promise.all(
+    entries.map(async entry => {
+      const filePath = path.join(dir, entry);
+      const isDir = (await fs.stat(filePath)).isDirectory();
+      return isDir ? listFiles(filePath) : [filePath];
+    })
+  );
+
+  // Return the flattened array
+  return paths.reduce((list, paths) => list.concat(paths), []);
 }
 
 // Exports

--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -3,7 +3,7 @@
 
 // Modules
 var path                           = require('path');
-var fs                             = require('fs');
+var fs                             = require('fs-extra');
 var build_nested_pages             = require('../functions/build_nested_pages.js');
 var marked                         = require('marked');
 var toc                            = require('markdown-toc');
@@ -14,7 +14,7 @@ const contentsHandler = require('../core/contents');
 const utils = require('../core/utils');
 
 function route_wildcard (config) {
-  return function (req, res, next) {
+  return async function (req, res, next) {
 
     // Skip if nothing matched the wildcard Regex
     if (!req.params[0]) { return next(); }
@@ -31,87 +31,85 @@ function route_wildcard (config) {
       file_path = file_path.slice(0, -suffix.length - 1);
     }
 
-    if (!fs.existsSync(file_path)) { file_path += '.md'; }
+    if (!(await fs.pathExists(file_path))) { file_path += '.md'; }
 
-    fs.readFile(file_path, 'utf8', function (error, content) {
+    let content;
+    try {
+      content = await fs.readFile(file_path, 'utf8');
+    } catch (error) {
+      error.status = '404';
+      error.message = config.lang.error['404'];
+      return next(error);
+    }
 
-      if (error) {
-        error.status = '404';
-        error.message = config.lang.error['404'];
-        return next(error);
-      }
+    // Process Markdown files
+    if (path.extname(file_path) === '.md') {
 
-      // Process Markdown files
-      if (path.extname(file_path) === '.md') {
+      // Meta
+      var meta = contentProcessors.processMeta(content);
+      meta.custom_title = meta.title;
+      if (!meta.title) { meta.title = contentProcessors.slugToTitle(file_path); }
 
-        // Meta
-        var meta = contentProcessors.processMeta(content);
-        meta.custom_title = meta.title;
-        if (!meta.title) { meta.title = contentProcessors.slugToTitle(file_path); }
+      // Content
+      content = contentProcessors.stripMeta(content);
+      content = contentProcessors.processVars(content, config);
 
-        // Content
-        content = contentProcessors.stripMeta(content);
-        content = contentProcessors.processVars(content, config);
+      var template = meta.template || 'page';
+      var render   = template;
 
-        var template = meta.template || 'page';
-        var render   = template;
+      // Check for "/edit" suffix
+      if (file_path_orig.indexOf(suffix, file_path_orig.length - suffix.length) !== -1) {
 
-        // Check for "/edit" suffix
-        if (file_path_orig.indexOf(suffix, file_path_orig.length - suffix.length) !== -1) {
+        // Edit Page
+        if ((config.authentication || config.authentication_for_edit) && !req.session.loggedIn) {
+          res.redirect('/login');
+          return;
+        }
+        render  = 'edit';
 
-          // Edit Page
-          if ((config.authentication || config.authentication_for_edit) && !req.session.loggedIn) {
-            res.redirect('/login');
-            return;
+      } else {
+
+        // Render Table of Contents
+        if (config.table_of_contents) {
+          var tableOfContents = toc(content);
+          if (tableOfContents.content) {
+            content = '#### Table of Contents\n' + tableOfContents.content + '\n\n' + content;
           }
-          render  = 'edit';
-
-        } else {
-
-          // Render Table of Contents
-          if (config.table_of_contents) {
-            var tableOfContents = toc(content);
-            if (tableOfContents.content) {
-              content = '#### Table of Contents\n' + tableOfContents.content + '\n\n' + content;
-            }
-          }
-
-          // Render Markdown
-          marked.setOptions({
-            langPrefix : ''
-          });
-          content = marked(content);
-
         }
 
-        var pageList = remove_image_content_directory(config, contentsHandler(slug, config));
-
-        var loggedIn = ((config.authentication || config.authentication_for_edit) ? req.session.loggedIn : false);
-
-        var canEdit = false;
-        if (config.authentication || config.authentication_for_edit) {
-          canEdit = loggedIn && config.allow_editing;
-        } else {
-          canEdit = config.allow_editing;
-        }
-
-        return res.render(render, {
-          config        : config,
-          pages         : build_nested_pages(pageList),
-          meta          : meta,
-          content       : content,
-          body_class    : template + '-' + contentProcessors.cleanString(slug),
-          last_modified : utils.getLastModified(config, meta, file_path),
-          lang          : config.lang,
-          loggedIn      : loggedIn,
-          username      : (config.authentication ? req.session.username : null),
-          canEdit       : canEdit
+        // Render Markdown
+        marked.setOptions({
+          langPrefix : ''
         });
+        content = marked(content);
 
       }
 
-    });
+      var pageList = remove_image_content_directory(config, await contentsHandler(slug, config));
 
+      var loggedIn = ((config.authentication || config.authentication_for_edit) ? req.session.loggedIn : false);
+
+      var canEdit = false;
+      if (config.authentication || config.authentication_for_edit) {
+        canEdit = loggedIn && config.allow_editing;
+      } else {
+        canEdit = config.allow_editing;
+      }
+
+      return res.render(render, {
+        config        : config,
+        pages         : build_nested_pages(pageList),
+        meta          : meta,
+        content       : content,
+        body_class    : template + '-' + contentProcessors.cleanString(slug),
+        last_modified : await utils.getLastModified(config, meta, file_path),
+        lang          : config.lang,
+        loggedIn      : loggedIn,
+        username      : (config.authentication ? req.session.username : null),
+        canEdit       : canEdit
+      });
+
+    }
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raneto",
-  "version": "0.16.0",
+  "version": "0.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2463,6 +2463,16 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -2519,14 +2529,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2541,20 +2549,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2671,8 +2676,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2684,7 +2688,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2699,7 +2702,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2707,14 +2709,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2733,7 +2733,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2814,8 +2813,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2827,7 +2825,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2949,7 +2946,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3245,8 +3241,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "gray-matter": {
       "version": "2.1.1",
@@ -3902,6 +3897,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "just-debounce": {
       "version": "1.0.0",
@@ -6731,6 +6734,11 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "express-session": "1.15.6",
     "extend": "3.0.2",
     "fitvids": "2.0.0",
+    "fs-extra": "^7.0.0",
     "glob": "7.1.3",
     "highlightjs": "9.12.0",
     "hogan-express": "0.5.2",

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -30,17 +30,17 @@ const config = {
 
 describe('#get_last_modified()', function () {
 
-  it('returns last modified from page meta', function () {
+  it('returns last modified from page meta', async function () {
     const file_path = path.join(__dirname, 'content/page-with-bom-yaml.md');
     const content = fs.readFileSync(file_path, 'utf8');
-    const modified = utils.getLastModified(config, contentProcessors.processMeta(content), file_path);
+    const modified = await utils.getLastModified(config, contentProcessors.processMeta(content), file_path);
     expect(modified).to.be.equal('14th Sep 2016');
   });
 
-  it('returns last modified from fs', function () {
+  it('returns last modified from fs', async function () {
     const file_path = path.join(__dirname, 'content/example-page.md');
     const content = fs.readFileSync(file_path, 'utf8');
-    const modified = utils.getLastModified(config, contentProcessors.processMeta(content), file_path);
+    const modified = await utils.getLastModified(config, contentProcessors.processMeta(content), file_path);
     const fstime = moment(fs.lstatSync(file_path).mtime).format(config.datetime_format);
     expect(modified).to.be.equal(fstime);
   });
@@ -49,8 +49,8 @@ describe('#get_last_modified()', function () {
 
 describe('#build_nested_pages()', function () {
 
-  it('builds tree of pages', function () {
-    const pages = contentsHandler(null, config);
+  it('builds tree of pages', async function () {
+    const pages = await contentsHandler(null, config);
     const result = build_nested_pages(pages);
 
     expect(result.length).to.be.equal(2);

--- a/test/raneto-core.test.js
+++ b/test/raneto-core.test.js
@@ -83,8 +83,8 @@ describe('#processMeta()', () => {
     expect(result).to.be.empty;
   });
 
-  it('returns proper meta from file starting with a BOM character', () => {
-    const result = pageHandler(
+  it('returns proper meta from file starting with a BOM character', async () => {
+    const result = await pageHandler(
       path.join(config.content_dir, 'page-with-bom.md'),
       config
     );
@@ -104,8 +104,8 @@ describe('#processMeta()', () => {
     expect(result).to.have.property('multi_word', 'Value');
   });
 
-  it('returns proper meta from file starting with a BOM character (YAML)', () => {
-    const result = pageHandler(
+  it('returns proper meta from file starting with a BOM character (YAML)', async () => {
+    const result = await pageHandler(
       path.join(config.content_dir, 'page-with-bom-yaml.md'),
       config
     );
@@ -187,8 +187,8 @@ describe('#processVars()', () => {
 
 describe('#getPage()', () => {
 
-  it('returns an array of values for a given page', () => {
-    const result = pageHandler(
+  it('returns an array of values for a given page', async () => {
+    const result = await pageHandler(
       path.join(config.content_dir, 'example-page.md'),
       config
     );
@@ -198,8 +198,8 @@ describe('#getPage()', () => {
     expect(result).to.have.property('excerpt');
   });
 
-  it('returns null if no page found', () => {
-    const result = pageHandler(
+  it('returns null if no page found', async () => {
+    const result = await pageHandler(
       path.join(config.content_dir, 'nonexistent-page.md'),
       config
     );
@@ -211,58 +211,58 @@ describe('#getPage()', () => {
 
 describe('#getPages()', () => {
 
-  it('returns an array of categories and pages', () => {
-    const result = contentsHandler(null, config);
+  it('returns an array of categories and pages', async () => {
+    const result = await contentsHandler(null, config);
     expect(result[0]).to.have.property('is_index', true);
     expect(result[0].files[0]).to.have.property('title', 'Example Page');
     expect(result[1]).to.have.property('slug', 'sub');
     expect(result[1].files[0]).to.have.property('title', 'Example Sub Page');
   });
 
-  it('marks activePageSlug as active', () => {
-    const result = contentsHandler('/example-page', config);
+  it('marks activePageSlug as active', async () => {
+    const result = await contentsHandler('/example-page', config);
     expect(result[0]).to.have.property('active', true);
     expect(result[0].files[0]).to.have.property('active', true);
     expect(result[1]).to.have.property('active', false);
     expect(result[1].files[0]).to.have.property('active', false);
   });
 
-  it('adds show_on_home property to directory', () => {
-    const result = contentsHandler(null, config);
+  it('adds show_on_home property to directory', async () => {
+    const result = await contentsHandler(null, config);
     expect(result[0]).to.have.property('show_on_home', true);
   });
 
-  it('adds show_on_home property to files', () => {
-    const result = contentsHandler(null, config);
+  it('adds show_on_home property to files', async () => {
+    const result = await contentsHandler(null, config);
     expect(result[0].files[0]).to.have.property('show_on_home', true);
   });
 
-  it('loads meta show_on_home value from directory', () => {
-    const result = contentsHandler(null, config);
+  it('loads meta show_on_home value from directory', async () => {
+    const result = await contentsHandler(null, config);
     expect(result[3]).to.have.property('show_on_home', false);
   });
 
-  it('loads meta show_on_home value from file', () => {
-    const result = contentsHandler(null, config);
+  it('loads meta show_on_home value from file', async () => {
+    const result = await contentsHandler(null, config);
     expect(result[0].files[4]).to.have.property('show_on_home', false);
   });
 
-  it('applies show_on_home_default in absence of meta for directories', () => {
-    const result = contentsHandler(null, Object.assign(config, {
+  it('applies show_on_home_default in absence of meta for directories', async () => {
+    const result = await contentsHandler(null, Object.assign(config, {
       show_on_home_default: false
     }));
     expect(result[1]).to.have.property('show_on_home', false);
   });
 
-  it('applies show_on_home_default in absence of meta for files', () => {
-    const result = contentsHandler(null, Object.assign(config, {
+  it('applies show_on_home_default in absence of meta for files', async () => {
+    const result = await contentsHandler(null, Object.assign(config, {
       show_on_home_default: false
     }));
     expect(result[1].files[0]).to.have.property('show_on_home', false);
   });
 
-  it('category index always shows on home', () => {
-    const result = contentsHandler(null, Object.assign(config, {
+  it('category index always shows on home', async () => {
+    const result = await contentsHandler(null, Object.assign(config, {
       show_on_home_default: false
     }));
     expect(result[0]).to.have.property('show_on_home', true);
@@ -271,18 +271,18 @@ describe('#getPages()', () => {
 });
 
 describe('#doSearch()', () => {
-  it('returns an array of search results', () => {
-    const result = searchHandler('example', config);
+  it('returns an array of search results', async () => {
+    const result = await searchHandler('example', config);
     expect(result).to.have.length(5);
   });
 
-  it('recognizes multiple languages', () => {
-    const result = searchHandler('пример', config);
+  it('recognizes multiple languages', async () => {
+    const result = await searchHandler('пример', config);
     expect(result).to.have.length(1);
   });
 
-  it('returns an empty array if nothing found', () => {
-    const result = searchHandler('qwerty', config);
+  it('returns an empty array if nothing found', async () => {
+    const result = await searchHandler('qwerty', config);
     /* eslint-disable no-unused-expressions */
     expect(result).to.be.empty;
   });


### PR DESCRIPTION
Make all file system calls async.

Currently all files ystem calls are sync, this means that the server can handle a single request at a time.
Each page or search request constructs the whole index, meaning that each request needs to read the whole content from disk, and doing this synchronously blocks the whole server until it's done.

Because Raneto now supports only Node 8+ we can take advantage of `Promises` and `async/await` to write asynchronous code that looks similar to the synchronous one.

It adds `fs-extra` dependency that allows to use all `fs` functions as Promise. Also provides other useful functions for creating paths and pruning directories.