### PR TITLE
Allow configuration of table of contents via config file

### DIFF
--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -71,7 +71,7 @@ function route_wildcard (config) {
 
         // Render Table of Contents
         if (config.table_of_contents) {
-          var tableOfContents = toc(content);
+          var tableOfContents = toc(content, config.table_of_contents_options);
           if (tableOfContents.content) {
             content = '#### Table of Contents\n' + tableOfContents.content + '\n\n' + content;
           }

--- a/example/config.default.js
+++ b/example/config.default.js
@@ -114,7 +114,15 @@ var config = {
   //   }
   // ]
 
-  table_of_contents: false
+  // Set to true to enable generation of table of contents
+  table_of_contents: false,
+
+  // Configure generation of table of contents (see markdown-toc's docs for details on available options)
+  table_of_contents_options: {
+    // append: 'Table of contents appendix',
+    // maxdepth: 6,
+    // firsth1: true,
+  }
 
 };
 config.public_dir = path.join(__dirname, '..', 'themes', config.theme_name, 'public');


### PR DESCRIPTION
This adds an attribute `table_of_contents_options` to Raneto's config file and passes it to [markdown-toc](https://www.npmjs.com/package/markdown-toc).

If the attribute is not specified in the config file, `undefined` is passed to markdown-toc which results in the same behavior as before.

Fixes #303