### PR TITLE
Fix: #189 Respect base_url setting and serve content and assets

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -132,7 +132,15 @@ function initialize (config) {
   router.use(error_handler);
   app.use(config.prefix_url || '/', router);
 
-  return app;
+  // Wrap App if base_url is set
+  if (config.base_url !== '' && config.nowrap !== true) {
+    var wrap_app = express();
+    wrap_app.set('port', process.env.PORT || 3000);
+    wrap_app.use(config.base_url, app);
+    return wrap_app;
+  } else {
+    return app;
+  }
 
 }
 

--- a/example/multiple-instances.js
+++ b/example/multiple-instances.js
@@ -21,8 +21,8 @@ const config = require('./config.default.js');
 const express = require('express');
 
 // Create two subapps with different configurations
-const appEn = raneto(Object.assign({}, config, { base_url : '/en', locale : 'en' }));
-const appEs = raneto(Object.assign({}, config, { base_url : '/es', locale : 'es' }));
+const appEn = raneto(Object.assign({}, config, { base_url : '/en', locale : 'en', nowrap : true }));
+const appEs = raneto(Object.assign({}, config, { base_url : '/es', locale : 'es', nowrap : true }));
 
 // Create the main app
 const mainApp = express();


### PR DESCRIPTION
Solves #189 

To test:
- Clone repo
- `make start`
- Validate service on `http://localhost:3000/`
- Edit `example/config.default.js` to `base_url: '/mydocs',`
- Restart service
- Validate service on `http://localhost:3000/mydocs/`
- Stop service
- Validate multi-host of service by running `node example/multiple-instances.js`
- Validate service on `http://localhost:3000/en/` and `http://localhost:3000/es/`
^ Note that the multiple-service script passes a `nowrap` setting to prevent a double-wrap, one from `app/index.js` and the other in the `multiple-instances.js` script itself, which would lead to `http://localhost:3000/en/en/`