### PR TITLE
Added Google groups restriction feature

### DIFF
--- a/example/config.default.js
+++ b/example/config.default.js
@@ -67,6 +67,11 @@ var config = {
 
   // Google OAuth
   googleoauth: false,
+  google_group_restriction: {
+    enabled: false,
+    api_key: 'GOOGLE_API_KEY',
+    group_name : 'GOOGLE_GROUP_NAME'
+  },
   oauth2 : {
     client_id: 'GOOGLE_CLIENT_ID',
     client_secret: 'GOOGLE_CLIENT_SECRET',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4975,6 +4975,11 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "masonry-layout": "4.2.2",
     "moment": "2.24.0",
     "morgan": "1.9.1",
+    "node-fetch": "^2.6.0",
     "passport": "0.4.0",
     "passport-google-oauth20": "2.0.0",
     "popper.js": "1.15.0",


### PR DESCRIPTION
Added feature that restricts access to Raneto only to the selected google group.

Useful if you want to limit acceess to your knownledge base only to curated list of members of your organization.

In order to use it, you need to enable AdminSDK access for your Google application, and generate API key, that needs to be pasted in confg file