### PR TITLE
Add description in the meta categories file

### DIFF
--- a/app/core/contents.js
+++ b/app/core/contents.js
@@ -99,6 +99,7 @@ async function processFile (config, activePageSlug, contentDir, filePath) {
       active: activePageSlug.startsWith('/' + fileSlug),
       class: 'category-' + contentProcessors.cleanString(fileSlug),
       sort: dirMetadata.sort || sort,
+      description: dirMetadata.description || '',
       files: []
     };
 

--- a/example/content/usage/category-meta.md
+++ b/example/content/usage/category-meta.md
@@ -8,5 +8,6 @@ Sort: 0
  * Title - This variable will override the title based on the folder name.
  * Sort - This variable will affect the sorting of the categories.
  * ShowOnHome - Optional. If false, categoru won't show on the home page. Default behavior can be changed through `config.show_on_home_default`.
+ * Description - Optional. This variable will provide a variable to be used in the templates, for example in the hompage, to enhance and clarify the content of the category.
 
  Note that `config.show_on_home_default` sets the default behavior for pages too.


### PR DESCRIPTION
You can now add a meta description to the categories, to be used in the templates, for example in the homepage to further add details to each group of links.