### PR TITLE
New: Defaulting listening IP address and adding override

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -45,7 +45,8 @@ function initialize (config) {
   var app = express();
   var router = express.Router();
 
-  // Setup Port
+  // Set IP Address and Port
+  app.set('host', process.env.HOST || '127.0.0.1');
   app.set('port', process.env.PORT || 3000);
 
   // set locale as date and time format

--- a/example/content/install/production-notes.md
+++ b/example/content/install/production-notes.md
@@ -10,5 +10,17 @@ Instead it is preferred to use a reverse proxy for security reasons.
 Heroku and other services handle this aspect for you, but you can implement your own reverse proxy with Nginx or Apache.
 **See [Related Projects](%base_url%/related-projects) for deployment scripts to use on your own servers**
 
-You can change the port anytime by setting the environment variable in your shell's profile, or running in-line as below:
+## Listening Port
+You can change the listening port anytime by setting the environment variable in your shell's profile, or running in-line as below:
 `$ PORT=1234 npm start`
+
+## Listening Host Address / IP
+
+### Defaults
+Raneto listens only to localhost (`127.0.0.1`) traffic by default now (v0.17.0).  
+This is to prevent unintended exposure and access of your documentation from older versions.  
+Previous versions before v0.17.0 would bind to all IP addresses, which could accidentally make documents available on the public internet.  
+
+### Override
+To override the default IP host, please look above at an Nginx reverse proxy to access `127.0.0.1` or you can manually set the IP Host (private or public) setting the Environment Variable `HOST` somewhere.  
+`$ HOST=192.168.0.10 npm start`

--- a/example/multiple-instances.js
+++ b/example/multiple-instances.js
@@ -30,8 +30,10 @@ mainApp.use('/en', appEn);
 mainApp.use('/es', appEs);
 
 // Load the HTTP Server
-const server = mainApp.listen(3000, function () {
+const server = mainApp.listen(appEn.get('port'), appEn.get('host'), function () {
   debug('Express HTTP server listening on port ' + server.address().port);
 });
 
-// Now navigate to http://localhost:3000/en and http://localhost:3000/es
+// Now you can navigate to both:
+// - http://localhost:3000/en
+// - http://localhost:3000/es

--- a/example/server.js
+++ b/example/server.js
@@ -23,6 +23,6 @@ var config = require('./config.default.js');
 var app = raneto(config);
 
 // Load the HTTP Server
-var server = app.listen(app.get('port'), function () {
+var server = app.listen(app.get('port'), app.get('host'), function () {
   debug('Express HTTP server listening on port ' + server.address().port);
 });


### PR DESCRIPTION
**Updates to fix #344**
- Default listening address is now `127.0.0.1` instead of all interfaces.
- Override is allowed by specifying `HOST` environment variable.
- Allowed values of `HOST` are anything the core Node.js net server listener can handle. [docs link](https://nodejs.org/api/net.html#net_server_listen).

**Netstat Output**
Before: `TCP *:3000 (LISTEN)`
After: `TCP 127.0.0.1:3000 (LISTEN)`

**Possible issues**
- EnvVar Name
- Multiple IPs (IPv4/IPv6) addresses

Requested by @meepmeep