### PR TITLE
fix local docker build and run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+node_modules/
+bin/
+test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM node
 
 EXPOSE 3000
+ENV HOST 0.0.0.0
+ENV PORT 3000
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 
-RUN npm install --production && \
-	./node_modules/gulp/bin/gulp.js
+RUN npm install --production
+RUN ./node_modules/gulp/bin/gulp.js
 
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "sweetalert2": "10.16.7",
     "underscore": "1.13.1",
     "underscore.string": "3.3.5",
-    "validator": "13.6.0"
+    "validator": "13.6.0",
+    "gulp": "4.0.2"
   },
   "devDependencies": {
     "chai": "4.3.4",
@@ -84,7 +85,6 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.3.1",
-    "gulp": "4.0.2",
     "gulp-shell": "0.8.0",
     "mocha": "8.4.0",
     "pm2": "4.5.6",


### PR DESCRIPTION
Fix #354 unable to build docker container.

Add `gulp` to normal node dependencies as currently not installed with `npm install --production` flag but is necessary to run with `npm start` in the container.  
Add dockerignore file  to ignore `node_modules` and other larger directories which slow down the docker build from `COPY . /usr/src/app`.  
Bind on `0.0.0.0` so Raneto can be accessed from outside the container if the port is forwarded.

I have tested mounting a local content folder into the container at `/usr/src/app/example/content` and it works as expected.