### PR TITLE
fix: support editing pages in nested subcategories

### DIFF
--- a/app/functions/getFilepath.js
+++ b/app/functions/getFilepath.js
@@ -8,9 +8,11 @@ function getFilepath(p) {
   // Default
   let filepath = p.content;
 
-  // Add Category
+  // Add Category - support multi-level paths (e.g. 'projects/Tasks')
   if (p.category) {
-    filepath += `/${sanitizeFilename(sanitize(p.category))}`;
+    for (const part of p.category.split('/')) {
+      filepath += `/${sanitizeFilename(sanitize(part))}`;
+    }
   }
 
   // Add File Name
@@ -42,9 +44,15 @@ function parseFileParam(fileParam) {
   if (!fileParam || fileParam.trim() === '') {
     return null;
   }
-  const parts = fileParam.split('/');
+  const parts = fileParam.split('/').filter((p) => p.length > 0);
+  if (parts.length === 0) {
+    return null;
+  }
   if (parts.length > 1) {
-    return { category: parts[0], filename: parts[1] };
+    return {
+      category: parts.slice(0, -1).join('/'),
+      filename: parts[parts.length - 1],
+    };
   }
   return { category: '', filename: parts[0] };
 }

--- a/test/writeRoutes.test.js
+++ b/test/writeRoutes.test.js
@@ -146,6 +146,29 @@ describe('pageEdit.route - path traversal prevention', () => {
 
     expect(res._json.status).toBe(0);
   });
+
+  it('allows editing a file nested two levels deep (category/subdir/file)', async () => {
+    const subDir = path.join(tmpDir, 'projects', 'Tasks');
+    await fs.mkdirp(subDir);
+    await fs.writeFile(path.join(subDir, 'Todo.md'), '');
+    const handler = route_page_edit(config);
+    const req = {
+      body: {
+        file: 'projects/Tasks/Todo',
+        content: 'Nested content',
+        meta_title: 'Todo',
+        meta_description: '',
+        meta_sort: '',
+      },
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res._json.status).toBe(0);
+    const saved = await fs.readFile(path.join(subDir, 'Todo.md'), 'utf8');
+    expect(saved).toContain('Nested content');
+  });
 });
 
 // pageDelete.route - path traversal (the critical one)


### PR DESCRIPTION
Fixes #406

## Problem

`parseFileParam` only handled one level of category nesting, taking `parts[0]` as category and `parts[1]` as filename. For a path like `projects/Tasks/Todo` (three parts), this resolved `filename='Tasks'`.

`getFilepath` then constructed a path pointing to the existing `Tasks/` **directory**. `resolveFilepath` saw the path existed (as a directory) and did not append `.md`, so `fs.writeFile` was called on a directory path — throwing `EISDIR`. This surfaced in the UI as **"Error Saving Page"**.

Pages at the root level or one category deep (`category/file`) were unaffected.

## Fix

**`parseFileParam`** — take the last segment as filename and all preceding segments joined as the category path:

```js
// Before
return { category: parts[0], filename: parts[1] };

// After
return {
  category: parts.slice(0, -1).join('/'),
  filename: parts[parts.length - 1],
};
```

**`getFilepath`** — split the category on `/` and sanitize each component individually, since `sanitizeFilename` strips path separators:

```js
// Before
filepath += `/${sanitizeFilename(sanitize(p.category))}`;

// After
for (const part of p.category.split('/')) {
  filepath += `/${sanitizeFilename(sanitize(part))}`;
}
```

The existing path-traversal protection in `getFilepath` (`resolved.startsWith(contentRoot + path.sep)`) continues to guard against `../../` attacks.

## Test

Adds a regression test in `writeRoutes.test.js` for the two-level-deep case (`projects/Tasks/Todo`).