### PR TITLE
Revise template customization tutorial with new methods

### DIFF
--- a/app/functions/contentProcessors.js
+++ b/app/functions/contentProcessors.js
@@ -19,6 +19,7 @@ import yaml from 'js-yaml';
 // TODO: DEPRECATED Non-YAML
 const META_REGEX = /^\uFEFF?\/\*([\s\S]*?)\*\//i;
 const META_REGEX_YAML = /^\uFEFF?---([\s\S]*?)---/i;
+const META_REGEX_YAML_TITLE = /^\uFEFF?---([\s\S]*?)---\n# (.*)/i;
 
 function cleanString(str, useUnderscore = false) {
   str = str.replaceAll('/', ' ').trim();
@@ -84,6 +85,10 @@ function processMeta(markdownContent) {
     const metaArr = markdownContent.match(META_REGEX_YAML);
     const metaString = metaArr?.[1]?.trim() ?? '';
     const yamlObject = yaml.load(metaString);
+    if (!("Title" in yamlObject && markdownContent.test(META_REGEX_YAML_TITLE))) {
+      const title = markdownContent.match(META_REGEX_YAML_TITLE)[2];
+      yamlObject.Title = title;
+    }
     return cleanObjectStrings(yamlObject);
   }
 

--- a/content/pages/tutorials/customizing-the-template.md
+++ b/content/pages/tutorials/customizing-the-template.md
@@ -2,9 +2,9 @@
 Title: Customizing the Template
 ---
 
-Templating in Raneto is powered by [Mustache](https://mustache.github.io/). All of the template views can
-be found in the `themes/default/` folder. Feel free to customize the template as you wish. The template structure
-is as follows:
+Templating in Raneto is powered by [Mustache](https://mustache.github.io/). 
+
+Feel free to customize the template as you wish. The template structure is as follows:
 
 - `layout.html`: The parent template. You'll probably want to customize this first
 - `home.html`: The homepage template. Shown if you don't have an [index.md](%base_url%/usage/custom-homepage)
@@ -13,6 +13,19 @@ is as follows:
 - `error.html`: Shown when Raneto encounters an error or can't find a page
 
 Remember you will need to restart the app after changing the template.
+
+## Previous way of installing a custom theme
+
+Templates can either be put in the application directory under `config.theme_dir` (which you can set to `/themes` for example). You choose the theme you wish with `config.theme_name` that corresponds to the sub-folder in the `config.theme_dir`.
+
+## New, better way of installing a custom theme
+
+The default theme is available under `@raneto/theme-default` on <https://github.com/raneto/theme-default>. 
+
+- Fork this module: https://github.com/raneto/theme-default
+- Publish your package with changes, whether public on GitHub or using a private NPM registry
+- install the module with npm install mytheme or similar `npm install @me/my-raneto-theme`
+- update the config file with your theme module name
 
 ## Enable Features on Pages by Altering Config Settings
 


### PR DESCRIPTION
Two adjustements:
1. Title from Markdown if not in YAML, but leaves slug if not in Markdown nor Yaml 
2. Documentation update for personalized themes

Addresses 
https://github.com/ryanlelek/Raneto/issues/208
https://github.com/ryanlelek/Raneto/issues/387

Sorry about the two different small changes in one PR