### PR TITLE
feat: add trust_proxy config option for reverse proxy deployments

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -71,6 +71,10 @@ function initialize(config) {
 
   // New Express App
   const app = express();
+  // Allow trust proxy to be configured for reverse proxy deployments (e.g. nginx, NPM)
+  if (config.trust_proxy !== undefined) {
+    app.set('trust proxy', config.trust_proxy);
+  }
   const router = express.Router();
 
   // Set IP Address and Port

--- a/config/config.js
+++ b/config/config.js
@@ -31,6 +31,14 @@ const config = {
   base_url: '',
   nowrap: true,
 
+  // Trust Proxy
+  // Set this when Raneto is deployed behind a reverse proxy (e.g. nginx, Nginx Proxy Manager).
+  // This allows express-rate-limit to read real client IPs from X-Forwarded-For headers
+  // and silences the "trust proxy is not set" startup warning.
+  // Set to 1 if there is one proxy; 2 if there are two; or true to trust any proxy.
+  // Leave undefined (omit this line) if not behind a reverse proxy.
+  // trust_proxy: 1,
+
   // Path Prefix
   // If you are running Raneto on a subpath of your domain, add it here
   // Leave it blank if you are not sure

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,21 @@
+import initialize from '../app/index.js';
+import { createConfig } from './configHelpers.js';
+
+const baseConfig = () => ({
+  ...createConfig(),
+  session_secret: 'a-valid-session-secret-for-testing-purposes',
+});
+
+describe('initialize() - trust proxy', () => {
+  it('sets trust proxy on app when trust_proxy is configured', () => {
+    const config = { ...baseConfig(), trust_proxy: 1 };
+    const app = initialize(config);
+    expect(app.get('trust proxy')).toBe(1);
+  });
+
+  it('leaves trust proxy at Express default when trust_proxy is not configured', () => {
+    const config = baseConfig();
+    const app = initialize(config);
+    expect(app.get('trust proxy')).toBe(false);
+  });
+});


### PR DESCRIPTION
Resolves #413

When deployed behind a reverse proxy, express-rate-limit warns that trust proxy is not set. Add a trust_proxy config option that calls app.set('trust proxy', value) when present.