### PR TITLE
fix/updated-default-json-body-limit-from-100kb-to-5000kb

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -155,8 +155,9 @@ function initialize(config) {
       crossOriginEmbedderPolicy: false,
     }),
   );
-  app.use(body_parser.json());
-  app.use(body_parser.urlencoded({ extended: false }));
+  // Maximum body request size 5mb. Anything above throws 'PayLoadTooLarge' error.
+  app.use(body_parser.json({ limit: '5000kb' }));
+  app.use(body_parser.urlencoded({ limit: '5000kb', extended: false }));
   app.use(cookie_parser());
   app.use(express.static(config.public_dir));
   if (config.theme_dir !== path.join(__dirname, '..', 'themes')) {


### PR DESCRIPTION
Bug #384 has been fixed. The data limit for per page has been increased from "100kb" to "5000kb". If it's unreasonable let me know any other value that is acceptable, I'll make the necessary changes. 

Error description: 
When the content exceeded the default express `"100kb"`  limit, express threw `PayLoadTooBigError` error. 

##### Error inducing code: 

<img width="477" height="53" alt="Screenshot 2026-04-21 085030" src="https://github.com/user-attachments/assets/6cf1739d-9985-46dc-bd7f-cdf79c091d41" />

<img width="391" height="22" alt="Screenshot 2026-04-21 085122" src="https://github.com/user-attachments/assets/4b8c7597-b01f-435e-abd9-c519625e4fb1" />

<img width="946" height="255" alt="Screenshot 2026-04-21 085151" src="https://github.com/user-attachments/assets/a94f4e90-80f1-4122-848d-c67174f94d53" />

##### Updated code: ( Note: The calculation logs in the 2nd was used during testing phase and has not been included in the code )

<img width="697" height="62" alt="Screenshot 2026-04-21 085913" src="https://github.com/user-attachments/assets/4b51673f-e475-4172-826c-34a362335493" />
<img width="525" height="207" alt="Screenshot 2026-04-21 090016" src="https://github.com/user-attachments/assets/087a9224-b210-4365-9ac1-10b85661ae0d" />
<img width="925" height="349" alt="Screenshot 2026-04-21 090038" src="https://github.com/user-attachments/assets/cb502d46-e838-4ba0-9c5d-b786b5685bae" />

