### PR TITLE
Allow <details> and <summary> HTML tags in sanitized output

### DIFF
--- a/app/functions/sanitizeHtmlOutput.js
+++ b/app/functions/sanitizeHtmlOutput.js
@@ -4,6 +4,8 @@ const allowedTags = sanitizeHtml.defaults.allowedTags.concat([
   'img',
   'input',
   'del',
+  'details',
+  'summary',
 ]);
 
 const allowedAttributes = {
@@ -19,6 +21,7 @@ const allowedAttributes = {
   span: ['class'],
   code: ['class'],
   pre: ['class'],
+  details: ['open'],
 };
 
 function sanitizeHtmlOutput(html) {


### PR DESCRIPTION
## Summary

Fixes #412

The `sanitizeHtmlOutput` function uses `sanitize-html` with an explicit tag allowlist. `<details>` and `<summary>` were not included, so native HTML collapsible sections were silently stripped from rendered pages regardless of the `config.markdown.html: true` setting (which only affects the `marked` step, not the subsequent sanitization pass).

### Changes

- Added `'details'` and `'summary'` to `allowedTags`
- Added `'open'` to `allowedAttributes` for `details`, so `<details open>` renders correctly (section expanded by default)

### Test

A wiki page with the following content now renders collapsible sections correctly:

\`\`\`markdown
<details>
<summary>Click to expand</summary>

Content here.

</details>
\`\`\`